### PR TITLE
[Ftr]:load the API router config into the local memory

### DIFF
--- a/cmd/proxy/control.go
+++ b/cmd/proxy/control.go
@@ -52,6 +52,12 @@ var (
 				Value:  "configs/conf.yaml",
 			},
 			cli.StringFlag{
+				Name:   "api-config, a",
+				Usage:  "Load api configuration from `FILE`",
+				EnvVar: "DUBBOGO_PROXY_API_CONFIG",
+				Value:  "configs/api_config.yaml",
+			},
+			cli.StringFlag{
 				Name:   "log-config, lc",
 				Usage:  "Load log configuration from `FILE`",
 				EnvVar: "LOG_FILE",
@@ -73,6 +79,7 @@ var (
 		},
 		Action: func(c *cli.Context) error {
 			configPath := c.String("config")
+			apiConfigPath := c.String("api-config")
 			flagLogLevel := c.String("log-level")
 			logConfPath := c.String("log-config")
 
@@ -80,8 +87,10 @@ var (
 			if logLevel, ok := flagToLogLevel[flagLogLevel]; ok {
 				logger.SetLoggerLevel(logLevel)
 			}
-
 			logger.InitLog(logConfPath)
+			if _, err := config.LoadAPIConfigFromFile(apiConfigPath); err != nil {
+				logger.Info(err.Error())
+			}
 
 			limitCpus := c.Int("limit-cpus")
 			if limitCpus <= 0 {

--- a/configs/api_config.yaml
+++ b/configs/api_config.yaml
@@ -15,7 +15,7 @@ resources:
             - name: id
               required: false
         integrationRequest:
-          requestType: DUBBO
+          requestType: dubbo
           mappingParams:
             - name: queryStrings.id
               mapTo: 1

--- a/configs/api_config.yaml
+++ b/configs/api_config.yaml
@@ -8,35 +8,22 @@ resources:
       - filter0
     methods:
       - httpVerb: GET
-        filters:
-          - filterA
-          - filterB
         onAir: true
         inboundRequest:
           requestType: http
-          headers: 
-            - name: auth
-              required: true 
           queryStrings:
             - name: id
               required: false
-            - name: type
-              required: false
-          requestBody:
-            - definitionName: modelDefinition
         integrationRequest:
-          requestType: dubbo
+          requestType: DUBBO
           mappingParams:
             - name: queryStrings.id
               mapTo: 1
-          applicationName: BDTService
-          group: test
-          version: 1.0.0
-          interface: com.ikurento.user.UserProvider
-          Method: GetUser
-          paramTypes:
-            - java.lang.String
-          ClusterName: test_dubbo
+          applicationName: "BDTService"
+          interface: "com.ikurento.user.UserProvider"
+          method: "GetUser"
+          clusterName: "test_dubbo"
+
 definitions:
   - name: modelDefinition
     schema: >-

--- a/configs/client.yml
+++ b/configs/client.yml
@@ -3,44 +3,37 @@
 
 check: true
 # client
-request_timeout: "10s"
+request_timeout : "3s"
 # connect timeout
-connect_timeout: "3s"
+connect_timeout : "3s"
 
 # application config
 application:
-  organization: "dubbogo"
-  name: "dubbo-go-proxy"
-  module: "dubbo-go-proxy"
-  version: "1.0.0"
-  group: "test"
-  owner: "PTY"
-  environment: "dev"
+  organization : "dubbo-go-proxy"
+  name  : "DubboGoProxy"
+  module : "dubbogo proxy client"
+  version : "0.0.1"
+  owner : "DubboGoProxy"
+  environment : "dev"
 
-registries:
-  "zk_1":
+registries :
+  "hangzhouzk":
     protocol: "zookeeper"
-    timeout: "3s"
-    address: "127.0.0.1:2182"
+    timeout	: "3s"
+    address: "127.0.0.1:2181"
     username: ""
     password: ""
+
 references:
 
 protocol_conf:
   dubbo:
     reconnect_interval: 0
     connection_number: 2
-    heartbeat_period: "30s"
-    session_timeout: "360s"
-    fail_fast_timeout: "5s"
-    pool_size: 4
+    heartbeat_period: "5s"
+    session_timeout: "20s"
+    pool_size: 64
     pool_ttl: 600
-    # gr_pool_size is recommended to be set to [cpu core number] * 100
-    gr_pool_size: 200
-    # queue_len is recommended to be set to 64 or 128
-    queue_len: 64
-    # queue_number is recommended to be set to gr_pool_size / 20
-    queue_number: 10
     getty_session_param:
       compress_encoding: false
       tcp_no_delay: true
@@ -48,10 +41,9 @@ protocol_conf:
       keep_alive_period: "120s"
       tcp_r_buf_size: 262144
       tcp_w_buf_size: 65536
-      pkg_rq_size: 1024
       pkg_wq_size: 512
-      tcp_read_timeout: "1s"  #1
-      tcp_write_timeout: "5s" #5
-      wait_timeout: "5s"
-      max_msg_len: 10240000
+      tcp_read_timeout: "1s"
+      tcp_write_timeout: "5s"
+      wait_timeout: "1s"
+      max_msg_len: 10240
       session_name: "client"

--- a/configs/client.yml
+++ b/configs/client.yml
@@ -9,17 +9,17 @@ connect_timeout : "3s"
 
 # application config
 application:
-  organization : "dubbo-go-proxy"
-  name  : "DubboGoProxy"
-  module : "dubbogo proxy client"
-  version : "0.0.1"
-  owner : "DubboGoProxy"
-  environment : "dev"
+  organization: "dubbo-go-proxy"
+  name : "DubboGoProxy"
+  module: "dubbogo proxy client"
+  version: "0.0.1"
+  owner: "DubboGoProxy"
+  environment: "dev"
 
 registries :
   "hangzhouzk":
     protocol: "zookeeper"
-    timeout	: "3s"
+    timeout: "3s"
     address: "127.0.0.1:2181"
     username: ""
     password: ""

--- a/pkg/client/dubbo/dubbo_client.go
+++ b/pkg/client/dubbo/dubbo_client.go
@@ -169,7 +169,7 @@ func (dc *DubboClient) create(key string, irequest config.IntegrationRequest) *d
 	}
 	referenceConfig.Registry = strings.Join(registers, ",")
 
-	if irequest.Protocol == "" {
+	if len(irequest.Protocol) == 0 {
 		referenceConfig.Protocol = dubbo.DUBBO
 	} else {
 		referenceConfig.Protocol = irequest.Protocol
@@ -178,7 +178,7 @@ func (dc *DubboClient) create(key string, irequest config.IntegrationRequest) *d
 	referenceConfig.Version = irequest.Version
 	referenceConfig.Group = irequest.Group
 	referenceConfig.Generic = true
-	if irequest.Retries == "" {
+	if len(irequest.Retries) == 0 {
 		referenceConfig.Retries = "3"
 	} else {
 		referenceConfig.Retries = irequest.Retries

--- a/pkg/client/dubbo/dubbo_client.go
+++ b/pkg/client/dubbo/dubbo_client.go
@@ -159,9 +159,9 @@ func (dc *DubboClient) check(key string) bool {
 	}
 }
 
-func (dc *DubboClient) create(key string, dm config.IntegrationRequest) *dg.GenericService {
-	referenceConfig := dg.NewReferenceConfig(dm.Interface, context.TODO())
-	referenceConfig.InterfaceName = dm.Interface
+func (dc *DubboClient) create(key string, irequest config.IntegrationRequest) *dg.GenericService {
+	referenceConfig := dg.NewReferenceConfig(irequest.Interface, context.TODO())
+	referenceConfig.InterfaceName = irequest.Interface
 	referenceConfig.Cluster = constant.DEFAULT_CLUSTER
 	var registers []string
 	for k := range dgCfg.Registries {
@@ -169,19 +169,19 @@ func (dc *DubboClient) create(key string, dm config.IntegrationRequest) *dg.Gene
 	}
 	referenceConfig.Registry = strings.Join(registers, ",")
 
-	if dm.Protocol == "" {
+	if irequest.Protocol == "" {
 		referenceConfig.Protocol = dubbo.DUBBO
 	} else {
-		referenceConfig.Protocol = dm.Protocol
+		referenceConfig.Protocol = irequest.Protocol
 	}
 
-	referenceConfig.Version = dm.Version
-	referenceConfig.Group = dm.Group
+	referenceConfig.Version = irequest.Version
+	referenceConfig.Group = irequest.Group
 	referenceConfig.Generic = true
-	if dm.Retries == "" {
+	if irequest.Retries == "" {
 		referenceConfig.Retries = "3"
 	} else {
-		referenceConfig.Retries = dm.Retries
+		referenceConfig.Retries = irequest.Retries
 	}
 	dc.mLock.Lock()
 	defer dc.mLock.Unlock()
@@ -194,11 +194,11 @@ func (dc *DubboClient) create(key string, dm config.IntegrationRequest) *dg.Gene
 }
 
 // Get find a dubbo GenericService
-func (dc *DubboClient) Get(interfaceName, version, group string, dm config.IntegrationRequest) *dg.GenericService {
-	key := strings.Join([]string{dm.ApplicationName, interfaceName, version, group}, "_")
+func (dc *DubboClient) Get(interfaceName, version, group string, ir config.IntegrationRequest) *dg.GenericService {
+	key := strings.Join([]string{ir.ApplicationName, interfaceName, version, group}, "_")
 	if dc.check(key) {
 		return dc.get(key)
 	}
 
-	return dc.create(key, dm)
+	return dc.create(key, ir)
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -18,20 +18,20 @@
 package client
 
 import (
-	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
 )
 
 // Request request for endpoint
 type Request struct {
 	Body   []byte
 	Header map[string]string
-	Api    *model.Api
+	API    *router.API
 }
 
 // NewRequest create a request
-func NewRequest(b []byte, api *model.Api) *Request {
+func NewRequest(b []byte, api *router.API) *Request {
 	return &Request{
 		Body: b,
-		Api:  api,
+		API:  api,
 	}
 }

--- a/pkg/common/extension/discovery_service.go
+++ b/pkg/common/extension/discovery_service.go
@@ -22,17 +22,17 @@ import (
 )
 
 var (
-	apiDiscoveryServiceMap = map[string]service.ApiDiscoveryService{}
+	apiDiscoveryServiceMap = map[string]service.APIDiscoveryService{}
 )
 
-// SetApiDiscoveryService will store the @filter and @name
-func SetApiDiscoveryService(name string, ads service.ApiDiscoveryService) {
+// SetAPIDiscoveryService will store the @filter and @name
+func SetAPIDiscoveryService(name string, ads service.APIDiscoveryService) {
 	apiDiscoveryServiceMap[name] = ads
 }
 
-// GetMustApiDiscoveryService will return the service.ApiDiscoveryService
+// GetMustAPIDiscoveryService will return the service.APIDiscoveryService
 // if not found, it will panic
-func GetMustApiDiscoveryService(name string) service.ApiDiscoveryService {
+func GetMustAPIDiscoveryService(name string) service.APIDiscoveryService {
 	if ds, ok := apiDiscoveryServiceMap[name]; ok {
 		return ds
 	}

--- a/pkg/common/yaml/yaml.go
+++ b/pkg/common/yaml/yaml.go
@@ -32,9 +32,8 @@ func LoadYMLConfig(confProFile string) ([]byte, error) {
 	if len(confProFile) == 0 {
 		return nil, perrors.Errorf("configure file name is nil")
 	}
-
-	if path.Ext(confProFile) != ".yml" {
-		return nil, perrors.Errorf("configure file name{%v} suffix must be .yml", confProFile)
+	if path.Ext(confProFile) != ".yml" && path.Ext(confProFile) != ".yaml" {
+		return nil, perrors.Errorf("configure file name{%v} suffix must be .yml or .yaml", confProFile)
 	}
 
 	return ioutil.ReadFile(confProFile)

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -59,9 +59,9 @@ type RequestType string
 
 const (
 	// DubboRequest represents the dubbo request
-	DubboRequest RequestType = "DUBBO"
+	DubboRequest RequestType = "dubbo"
 	// HTTPRequest represents the http request
-	HTTPRequest RequestType = "HTTP"
+	HTTPRequest RequestType = "http"
 )
 
 // APIConfig defines the data structure of the api gateway configuration

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -22,7 +22,6 @@ import (
 )
 
 import (
-	"github.com/dubbogo/dubbo-go-proxy/pkg/client/dubbo"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/yaml"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/logger"
 )
@@ -97,15 +96,26 @@ type BodyDefinition struct {
 
 // IntegrationRequest defines the backend request format and target
 type IntegrationRequest struct {
-	RequestType         string         `json:"requestType" yaml:"requestType"` // dubbo, TO-DO: http
-	MappingParams       []MappingParam `json:"mappingParams,omitempty" yaml:"mappingParams,omitempty"`
-	dubbo.DubboMetadata `json:"dubboMetaData,inline,omitempty" yaml:"dubboMetaData,inline,omitempty"`
+	RequestType        string         `json:"requestType" yaml:"requestType"` // dubbo, TO-DO: http
+	MappingParams      []MappingParam `json:"mappingParams,omitempty" yaml:"mappingParams,omitempty"`
+	DubboBackendConfig `json:"dubboBackendConfig,inline,omitempty" yaml:"dubboBackendConfig,inline,omitempty"`
 }
 
 // MappingParam defines the mapping rules of headers and queryStrings
 type MappingParam struct {
 	Name  string `json:"name" yaml:"name"`
 	MapTo string `json:"mapTo" yaml:"mapTo"`
+}
+
+// DubboBackendConfig defines the basic dubbo backend config
+type DubboBackendConfig struct {
+	ApplicationName string   `yaml:"applicationName" json:"applicationName"`
+	Group           string   `yaml:"group" json:"group"`
+	Version         string   `yaml:"version" json:"version"`
+	Interface       string   `yaml:"interface" json:"interface"`
+	Method          string   `yaml:"method" json:"method" mapstructure:"method"`
+	ClusterName     string   `yaml:"clusterName"  json:"clusterName,omitempty"`
+	ParamTypes      []string `yaml:"paramTypes" json:"paramTypes"`
 }
 
 // Definition defines the complex json request body

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -51,67 +51,67 @@ const (
 
 // APIConfig defines the data structure of the api gateway configuration
 type APIConfig struct {
-	Name        string       `yaml:"name"`
-	Description string       `yaml:"description"`
-	Resources   []Resource   `yaml:"resources"`
-	Definitions []Definition `yaml:"definitions"`
+	Name        string       `json:"name" yaml:"name"`
+	Description string       `json:"description" yaml:"description"`
+	Resources   []Resource   `json:"resources" yaml:"resources"`
+	Definitions []Definition `json:"definitions" yaml:"definitions"`
 }
 
 // Resource defines the API path
 type Resource struct {
-	Type        string     `yaml:"type"` // Restful, Dubbo
-	Path        string     `yaml:"path"`
-	Description string     `yaml:"description"`
-	Filters     []string   `yaml:"filters"`
-	Methods     []Method   `yaml:"methods"`
-	Resources   []Resource `yaml:"resources,omitempty"`
+	Type        string     `json:"type" yaml:"type"` // Restful, Dubbo
+	Path        string     `json:"path" yaml:"path"`
+	Description string     `json:"description" yaml:"description"`
+	Filters     []string   `json:"filters" yaml:"filters"`
+	Methods     []Method   `json:"methods" yaml:"methods"`
+	Resources   []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
 // Method defines the method of the api
 type Method struct {
-	OnAir              bool     `yaml:"onAir"` // true means the method is up and false means method is down
-	Filters            []string `yaml:"filters"`
-	HTTPVerb           `yaml:"httpVerb"`
-	InboundRequest     `yaml:"inboundRequest"`
-	IntegrationRequest `yaml:"integrationRequest"`
+	OnAir              bool     `json:"onAir" yaml:"onAir"` // true means the method is up and false means method is down
+	Filters            []string `json:"filters" yaml:"filters"`
+	HTTPVerb           `json:"httpVerb" yaml:"httpVerb"`
+	InboundRequest     `json:"inboundRequest" yaml:"inboundRequest"`
+	IntegrationRequest `json:"integrationRequest" yaml:"integrationRequest"`
 }
 
 // InboundRequest defines the details of the inbound
 type InboundRequest struct {
-	RequestType  string           `yaml:"requestType"` //http, TO-DO: dubbo
-	Headers      []Params         `yaml:"headers"`
-	QueryStrings []Params         `yaml:"queryStrings"`
-	RequestBody  []BodyDefinition `yaml:"requestBody"`
+	RequestType  string           `json:"requestType" yaml:"requestType"` //http, TO-DO: dubbo
+	Headers      []Params         `json:"headers" yaml:"headers"`
+	QueryStrings []Params         `json:"queryStrings" yaml:"queryStrings"`
+	RequestBody  []BodyDefinition `json:"requestBody" yaml:"requestBody"`
 }
 
 // Params defines the simple parameter definition
 type Params struct {
-	Name     string `yaml:"name"`
-	Required bool   `yaml:"required"`
+	Name     string `json:"name" yaml:"name"`
+	Required bool   `json:"required" yaml:"required"`
 }
 
 // BodyDefinition connects the request body to the definitions
 type BodyDefinition struct {
-	DefinitionName string `yaml:"definitionName"`
+	DefinitionName string `json:"definitionName" yaml:"definitionName"`
 }
 
 // IntegrationRequest defines the backend request format and target
 type IntegrationRequest struct {
-	RequestType         string         `yaml:"requestType"` // dubbo, TO-DO: http
-	MappingParams       []MappingParam `yaml:"mappingParams,omitempty"`
-	dubbo.DubboMetadata `yaml:"dubboMetaData,inline,omitempty"`
+	RequestType         string         `json:"requestType" yaml:"requestType"` // dubbo, TO-DO: http
+	MappingParams       []MappingParam `json:"mappingParams,omitempty" yaml:"mappingParams,omitempty"`
+	dubbo.DubboMetadata `json:"dubboMetaData,inline,omitempty" yaml:"dubboMetaData,inline,omitempty"`
 }
 
 // MappingParam defines the mapping rules of headers and queryStrings
 type MappingParam struct {
-	Name  string `yaml:"name"`
-	MapTo string `yaml:"mapTo"`
+	Name  string `json:"name" yaml:"name"`
+	MapTo string `json:"mapTo" yaml:"mapTo"`
 }
 
 // Definition defines the complex json request body
 type Definition struct {
-	Name   string `yaml:"name"`
-	Schema string `yaml:"schema"` // use json schema
+	Name   string `json:"name" yaml:"name"`
+	Schema string `json:"schema" yaml:"schema"` // use json schema
 }
 
 // LoadAPIConfigFromFile load the api config from file
@@ -119,7 +119,7 @@ func LoadAPIConfigFromFile(path string) (*APIConfig, error) {
 	if len(path) == 0 {
 		return nil, perrors.Errorf("Config file not specified")
 	}
-	logger.Info("Load API configuration file form %s", path)
+	logger.Info("Load API configuration file form ", path)
 	apiConf := &APIConfig{}
 	err := yaml.UnmarshalYMLConfig(path, apiConf)
 	if err != nil {

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -147,7 +147,7 @@ func LoadAPIConfigFromFile(path string) (*APIConfig, error) {
 	if len(path) == 0 {
 		return nil, perrors.Errorf("Config file not specified")
 	}
-	logger.Info("Load API configuration file form ", path)
+	logger.Infof("Load API configuration file form %s", path)
 	apiConf := &APIConfig{}
 	err := yaml.UnmarshalYMLConfig(path, apiConf)
 	if err != nil {

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -48,6 +48,16 @@ const (
 	MethodOptions HTTPVerb = "OPTIONS"
 )
 
+// RequestType describes the type of the request. could be DUBBO/HTTP and others that we might implement in the future
+type RequestType string
+
+const (
+	// DubboRequest represents the dubbo request
+	DubboRequest RequestType = "DUBBO"
+	// HTTPRequest represents the http request
+	HTTPRequest RequestType = "HTTP"
+)
+
 // APIConfig defines the data structure of the api gateway configuration
 type APIConfig struct {
 	Name        string       `json:"name" yaml:"name"`
@@ -77,10 +87,10 @@ type Method struct {
 
 // InboundRequest defines the details of the inbound
 type InboundRequest struct {
-	RequestType  string           `json:"requestType" yaml:"requestType"` //http, TO-DO: dubbo
-	Headers      []Params         `json:"headers" yaml:"headers"`
-	QueryStrings []Params         `json:"queryStrings" yaml:"queryStrings"`
-	RequestBody  []BodyDefinition `json:"requestBody" yaml:"requestBody"`
+	RequestType  `json:"requestType" yaml:"requestType"` //http, TO-DO: dubbo
+	Headers      []Params                                `json:"headers" yaml:"headers"`
+	QueryStrings []Params                                `json:"queryStrings" yaml:"queryStrings"`
+	RequestBody  []BodyDefinition                        `json:"requestBody" yaml:"requestBody"`
 }
 
 // Params defines the simple parameter definition
@@ -96,8 +106,8 @@ type BodyDefinition struct {
 
 // IntegrationRequest defines the backend request format and target
 type IntegrationRequest struct {
-	RequestType        string         `json:"requestType" yaml:"requestType"` // dubbo, TO-DO: http
-	MappingParams      []MappingParam `json:"mappingParams,omitempty" yaml:"mappingParams,omitempty"`
+	RequestType        `json:"requestType" yaml:"requestType"` // dubbo, TO-DO: http
+	MappingParams      []MappingParam                          `json:"mappingParams,omitempty" yaml:"mappingParams,omitempty"`
 	DubboBackendConfig `json:"dubboBackendConfig,inline,omitempty" yaml:"dubboBackendConfig,inline,omitempty"`
 }
 

--- a/pkg/config/mock/api_config.yml
+++ b/pkg/config/mock/api_config.yml
@@ -37,6 +37,100 @@ resources:
           paramTypes:
             - java.lang.String
           ClusterName: test_dubbo
+  - path: '/mockTest'
+    type: restful
+    description: mockTest
+    filters:
+      - filter0
+    methods:
+      - httpVerb: GET
+        filters:
+          - filterA
+          - filterB
+        onAir: true
+        inboundRequest:
+          requestType: http
+          headers: 
+            - name: auth
+              required: true 
+          queryStrings:
+            - name: id
+              required: false
+            - name: type
+              required: false
+          requestBody:
+            - definitionName: modelDefinition
+        integrationRequest:
+          requestType: dubbo
+          mappingParams:
+            - name: queryStrings.id
+              mapTo: 1
+          applicationName: BDTService
+          group: test
+          version: 1.0.0
+          interface: com.ikurento.user.UserProvider
+          Method: GetUsers
+          paramTypes:
+            - java.lang.String
+          ClusterName: test_dubbo
+      - httpVerb: POST
+        filters:
+          - filterA
+        onAir: true
+        inboundRequest:
+          requestType: http
+          headers: 
+            - name: auth
+              required: true 
+          queryStrings:
+            - name: id
+              required: false
+            - name: type
+              required: false
+        integrationRequest:
+          requestType: dubbo
+          mappingParams:
+            - name: queryStrings.id
+              mapTo: 1
+          applicationName: BDTService
+          group: test
+          version: 1.0.0
+          interface: com.ikurento.user.UserProvider
+          Method: NewUser
+          paramTypes:
+            - java.lang.String
+          ClusterName: test_dubbo
+    resources:
+      - path: '/:id'
+        type: restful
+        description: resource documentation
+        filters:
+          - filter0
+        methods:
+          - httpVerb: GET
+            onAir: true
+            inboundRequest:
+              requestType: http
+              headers: 
+                - name: auth
+                  required: true 
+              queryStrings:
+                - name: id
+                  required: true
+            integrationRequest:
+              requestType: dubbo
+              mappingParams:
+                - name: queryStrings.id
+                  mapTo: 1
+              applicationName: BDTService
+              group: test
+              version: 1.0.0
+              interface: com.ikurento.user.UserProvider
+              Method: GetUser
+              paramTypes:
+                - java.lang.String
+              ClusterName: test_dubbo
+          
 definitions:
   - name: modelDefinition
     schema: >-

--- a/pkg/config/mock/api_config.yml
+++ b/pkg/config/mock/api_config.yml
@@ -69,10 +69,10 @@ resources:
           group: test
           version: 1.0.0
           interface: com.ikurento.user.UserProvider
-          Method: GetUsers
+          method: GetUsers
           paramTypes:
             - java.lang.String
-          ClusterName: test_dubbo
+          clusterName: test_dubbo
       - httpVerb: POST
         filters:
           - filterA
@@ -96,10 +96,10 @@ resources:
           group: test
           version: 1.0.0
           interface: com.ikurento.user.UserProvider
-          Method: NewUser
+          method: NewUser
           paramTypes:
             - java.lang.String
-          ClusterName: test_dubbo
+          clusterName: test_dubbo
     resources:
       - path: '/:id'
         type: restful
@@ -126,10 +126,10 @@ resources:
               group: test
               version: 1.0.0
               interface: com.ikurento.user.UserProvider
-              Method: GetUser
+              method: GetUser
               paramTypes:
                 - java.lang.String
-              ClusterName: test_dubbo
+              clusterName: test_dubbo
           
 definitions:
   - name: modelDefinition

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -19,6 +19,7 @@ package context
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
 )
 
 // Context run context
@@ -39,6 +40,8 @@ type Context interface {
 
 	BuildFilters()
 
+	API(router.API)
+	GetAPI() *router.API
 	Api(api *model.Api)
 	GetApi() *model.Api
 

--- a/pkg/context/http/context.go
+++ b/pkg/context/http/context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
 )
 
 // HttpContext http context
@@ -36,7 +37,7 @@ type HttpContext struct {
 	HttpConnectionManager model.HttpConnectionManager
 	FilterChains          []model.FilterChain
 	Listener              *model.Listener
-	api                   *model.Api
+	api                   router.API
 
 	Request   *http.Request
 	writermem responseWriter
@@ -107,12 +108,17 @@ func (hc *HttpContext) GetMethod() string {
 
 // Api
 func (hc *HttpContext) Api(api *model.Api) {
+	// hc.api = api
+}
+
+// API sets the API to http context
+func (hc *HttpContext) API(api router.API) {
 	hc.api = api
 }
 
-// GetApi get api
-func (hc *HttpContext) GetApi() *model.Api {
-	return hc.api
+// GetAPI get api
+func (hc *HttpContext) GetAPI() *router.API {
+	return &hc.api
 }
 
 // WriteFail
@@ -161,17 +167,17 @@ func (hc *HttpContext) doWrite(h map[string]string, code int, d interface{}) {
 
 // BuildFilters build filter, from config http_filters
 func (hc *HttpContext) BuildFilters() {
-	var ff []context.FilterFunc
+	var filterFuncs []context.FilterFunc
 
 	if hc.HttpConnectionManager.HttpFilters == nil {
 		return
 	}
 
 	for _, v := range hc.HttpConnectionManager.HttpFilters {
-		ff = append(ff, extension.GetMustFilterFunc(v.Name))
+		filterFuncs = append(filterFuncs, extension.GetMustFilterFunc(v.Name))
 	}
 
-	hc.AppendFilterFunc(ff...)
+	hc.AppendFilterFunc(filterFuncs...)
 }
 
 // ResetWritermen reset writermen

--- a/pkg/context/http/context_test.go
+++ b/pkg/context/http/context_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
@@ -29,7 +33,6 @@ import (
 	_ "github.com/dubbogo/dubbo-go-proxy/pkg/filter"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
-	"github.com/stretchr/testify/assert"
 )
 
 func getMockAPI(verb config.HTTPVerb, urlPattern string, filters ...string) router.API {

--- a/pkg/context/http/context_test.go
+++ b/pkg/context/http/context_test.go
@@ -1,0 +1,10 @@
+package http
+
+import (
+	"testing"
+)
+
+func TestBuildContext(t *testing.T) {
+	ctx := HttpContext{}
+	ctx.BuildFilters()
+}

--- a/pkg/context/http/context_test.go
+++ b/pkg/context/http/context_test.go
@@ -1,10 +1,63 @@
-package http
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http_test
 
 import (
 	"testing"
 )
 
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
+	httpCtx "github.com/dubbogo/dubbo-go-proxy/pkg/context/http"
+	_ "github.com/dubbogo/dubbo-go-proxy/pkg/filter"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
+	"github.com/stretchr/testify/assert"
+)
+
+func getMockAPI(verb config.HTTPVerb, urlPattern string, filters ...string) router.API {
+	inbound := config.InboundRequest{}
+	integration := config.IntegrationRequest{RequestType: config.DubboRequest}
+	method := config.Method{
+		OnAir:              true,
+		HTTPVerb:           verb,
+		InboundRequest:     inbound,
+		IntegrationRequest: integration,
+		Filters:            filters,
+	}
+	return router.API{
+		URLPattern: urlPattern,
+		Method:     method,
+	}
+}
+
 func TestBuildContext(t *testing.T) {
-	ctx := HttpContext{}
+	extension.SetFilterFunc("a", func(ctx context.Context) { ctx.Next() })
+	extension.SetFilterFunc("b", func(ctx context.Context) { ctx.Next() })
+	extension.SetFilterFunc("c", func(ctx context.Context) { ctx.Next() })
+	ctx := httpCtx.HttpContext{
+		FilterChains: []model.FilterChain{},
+		BaseContext:  context.NewBaseContext(),
+	}
+	ctx.API(getMockAPI(config.MethodPost, "/mock/test", "a", "b", "c"))
 	ctx.BuildFilters()
+
+	assert.Equal(t, len(ctx.Filters), 4)
 }

--- a/pkg/filter/api_filter.go
+++ b/pkg/filter/api_filter.go
@@ -37,7 +37,7 @@ func ApiFilter() context.FilterFunc {
 	return func(c context.Context) {
 		url := c.GetUrl()
 		method := c.GetMethod()
-
+		// [williamfeng323]TO-DO: get the API details from router which saved in constant.LocalMemoryApiDiscoveryService
 		if api, ok := model.EmptyApi.FindApi(url); ok {
 			if !api.MatchMethod(method) {
 				c.WriteWithStatus(http.StatusMethodNotAllowed, constant.Default405Body)
@@ -52,7 +52,7 @@ func ApiFilter() context.FilterFunc {
 				c.Abort()
 				return
 			}
-
+			// [williamfeng323]TO-DO: the c.Api method need to be updated to use the newest API definition
 			c.Api(api)
 			c.Next()
 		} else {

--- a/pkg/filter/dubbo_filter.go
+++ b/pkg/filter/dubbo_filter.go
@@ -51,7 +51,7 @@ func HttpDubbo() context.FilterFunc {
 }
 
 func doDubbo(c *http.HttpContext) {
-	api := c.GetApi()
+	api := c.GetAPI()
 
 	if bytes, err := ioutil.ReadAll(c.Request.Body); err != nil {
 		logger.Errorf("[dubboproxy go] read body err:%v!", err)

--- a/pkg/proxy/listener.go
+++ b/pkg/proxy/listener.go
@@ -141,7 +141,7 @@ func (s *DefaultHttpListener) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *DefaultHttpListener) routeRequest(ctx *h.HttpContext, req *http.Request) (router.API, error) {
-	apiDiscSrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	apiDiscSrv := extension.GetMustAPIDiscoveryService(constant.LocalMemoryApiDiscoveryService)
 	api, err := apiDiscSrv.GetAPI(req.URL.Path, config.HTTPVerb(req.Method))
 	if err != nil {
 		ctx.WriteWithStatus(http.StatusNotFound, constant.Default404Body)

--- a/pkg/proxy/listener.go
+++ b/pkg/proxy/listener.go
@@ -26,6 +26,10 @@ import (
 )
 
 import (
+	"github.com/pkg/errors"
+)
+
+import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
@@ -34,7 +38,6 @@ import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/logger"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
-	"github.com/pkg/errors"
 )
 
 // ListenerService the facade of a listener

--- a/pkg/proxy/listener.go
+++ b/pkg/proxy/listener.go
@@ -128,6 +128,11 @@ func (s *DefaultHttpListener) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		extension.GetMustFilterFunc(constant.RecoveryFilter),
 	)
 
+	_, err := s.routeRequest(hc, r)
+	if err != nil {
+		s.pool.Put(hc)
+		return
+	}
 	hc.BuildFilters()
 
 	s.handleHTTPRequest(hc)

--- a/pkg/proxy/listener_test.go
+++ b/pkg/proxy/listener_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package proxy
 
 import (

--- a/pkg/proxy/listener_test.go
+++ b/pkg/proxy/listener_test.go
@@ -79,7 +79,7 @@ func TestRouteRequest(t *testing.T) {
 	mockAPI := getMockAPI(config.MethodPost, "/mock/test")
 	mockAPI.Method.OnAir = false
 
-	apiDiscoverySrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	apiDiscoverySrv := extension.GetMustAPIDiscoveryService(constant.LocalMemoryApiDiscoveryService)
 	apiDiscoverySrv.AddAPI(mockAPI)
 	apiDiscoverySrv.AddAPI(getMockAPI(config.MethodGet, "/mock/test"))
 

--- a/pkg/proxy/listener_test.go
+++ b/pkg/proxy/listener_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
@@ -32,7 +36,6 @@ import (
 	ctxHttp "github.com/dubbogo/dubbo-go-proxy/pkg/context/http"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
-	"github.com/stretchr/testify/assert"
 )
 
 func getTestContext() *ctxHttp.HttpContext {
@@ -75,6 +78,7 @@ func getMockAPI(verb config.HTTPVerb, urlPattern string) router.API {
 		Method:     method,
 	}
 }
+
 func TestRouteRequest(t *testing.T) {
 	mockAPI := getMockAPI(config.MethodPost, "/mock/test")
 	mockAPI.Method.OnAir = false

--- a/pkg/proxy/listener_test.go
+++ b/pkg/proxy/listener_test.go
@@ -1,0 +1,96 @@
+package proxy
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
+	ctxHttp "github.com/dubbogo/dubbo-go-proxy/pkg/context/http"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestContext() *ctxHttp.HttpContext {
+	l := ListenerService{
+		Listener: &model.Listener{
+			Name: "test",
+			Address: model.Address{
+				SocketAddress: model.SocketAddress{
+					Protocol: model.HTTP,
+					Address:  "0.0.0.0",
+					Port:     8888,
+				},
+			},
+			FilterChains: []model.FilterChain{},
+		},
+	}
+
+	hc := &ctxHttp.HttpContext{
+		Listener:              l.Listener,
+		FilterChains:          l.FilterChains,
+		HttpConnectionManager: l.findHttpManager(),
+		BaseContext:           context.NewBaseContext(),
+	}
+	hc.ResetWritermen(httptest.NewRecorder())
+	hc.Reset()
+	return hc
+}
+
+func getMockAPI(verb config.HTTPVerb, urlPattern string) router.API {
+	inbound := config.InboundRequest{}
+	integration := config.IntegrationRequest{}
+	method := config.Method{
+		OnAir:              true,
+		HTTPVerb:           verb,
+		InboundRequest:     inbound,
+		IntegrationRequest: integration,
+	}
+	return router.API{
+		URLPattern: urlPattern,
+		Method:     method,
+	}
+}
+func TestRouteRequest(t *testing.T) {
+	mockAPI := getMockAPI(config.MethodPost, "/mock/test")
+	mockAPI.Method.OnAir = false
+
+	apiDiscoverySrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	apiDiscoverySrv.AddAPI(mockAPI)
+	apiDiscoverySrv.AddAPI(getMockAPI(config.MethodGet, "/mock/test"))
+
+	listener := NewDefaultHttpListener()
+	listener.pool.New = func() interface{} {
+		return getTestContext()
+	}
+	r := bytes.NewReader([]byte("test"))
+
+	req, _ := http.NewRequest("GET", "/mock/test", r)
+	ctx := listener.pool.Get().(*ctxHttp.HttpContext)
+	api, err := listener.routeRequest(ctx, req)
+	assert.Nil(t, err)
+	assert.NotNil(t, api)
+	assert.Equal(t, api.URLPattern, "/mock/test")
+	assert.Equal(t, api.HTTPVerb, config.MethodGet)
+
+	req, _ = http.NewRequest("GET", "/mock/test2", r)
+	ctx = listener.pool.Get().(*ctxHttp.HttpContext)
+	api, err = listener.routeRequest(ctx, req)
+	assert.EqualError(t, err, "Requested URL /mock/test2 not found")
+	assert.Equal(t, ctx.StatusCode(), 404)
+	assert.Equal(t, api, router.API{})
+
+	req, _ = http.NewRequest("POST", "/mock/test", r)
+	ctx = listener.pool.Get().(*ctxHttp.HttpContext)
+	api, err = listener.routeRequest(ctx, req)
+	assert.EqualError(t, err, "Requested API POST /mock/test does not online")
+	assert.Equal(t, ctx.StatusCode(), 406)
+	assert.Equal(t, api, router.API{})
+}

--- a/pkg/proxy/proxy_start.go
+++ b/pkg/proxy/proxy_start.go
@@ -18,20 +18,16 @@
 package proxy
 
 import (
-	"encoding/json"
 	"sync"
 )
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/client/dubbo"
-	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
-	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
 	_ "github.com/dubbogo/dubbo-go-proxy/pkg/filter"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/logger"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
-	"github.com/dubbogo/dubbo-go-proxy/pkg/service"
-	_ "github.com/dubbogo/dubbo-go-proxy/pkg/service/api"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/service/api"
 )
 
 // Proxy
@@ -65,54 +61,7 @@ func (p *Proxy) Start() {
 func (p *Proxy) beforeStart() {
 	dubbo.SingleDubboClient().Init()
 
-	// TODO mock api register
-	ads := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
-
-	a1 := &model.Api{
-		Name:     "/api/v1/test-dubbo/user",
-		ITypeStr: "HTTP",
-		OTypeStr: "DUBBO",
-		Method:   "POST",
-		Status:   1,
-		Metadata: map[string]dubbo.DubboMetadata{
-			"dubbo": {
-				ApplicationName: "BDTService",
-				Group:           "test",
-				Version:         "1.0.0",
-				Interface:       "com.ikurento.user.UserProvider",
-				Method:          "queryUser",
-				Types: []string{
-					"com.ikurento.user.User",
-				},
-				ClusterName: "test_dubbo",
-			},
-		},
-	}
-	a2 := &model.Api{
-		Name:     "/api/v1/test-dubbo/getUserByName",
-		ITypeStr: "HTTP",
-		OTypeStr: "DUBBO",
-		Method:   "POST",
-		Status:   1,
-		Metadata: map[string]dubbo.DubboMetadata{
-			"dubbo": {
-				ApplicationName: "BDTService",
-				Group:           "test",
-				Version:         "1.0.0",
-				Interface:       "com.ikurento.user.UserProvider",
-				Method:          "GetUser",
-				Types: []string{
-					"java.lang.String",
-				},
-				ClusterName: "test_dubbo",
-			},
-		},
-	}
-
-	j1, _ := json.Marshal(a1)
-	j2, _ := json.Marshal(a2)
-	ads.AddApi(*service.NewDiscoveryRequest(j1))
-	ads.AddApi(*service.NewDiscoveryRequest(j2))
+	api.InitAPIsFromConfig(config.GetAPIConf())
 }
 
 // NewProxy create proxy

--- a/pkg/router/api.go
+++ b/pkg/router/api.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package service
+package router
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -47,38 +47,38 @@ func TestPut(t *testing.T) {
 		wildcardTree: avltree.NewWithStringComparator(),
 	}
 	n0 := getMockMethod(config.MethodGet)
-	rt.Put("/", n0)
+	rt.PutAPI(API{URLPattern: "/", Method: n0})
 	_, ok := rt.tree.Get("/")
 	assert.True(t, ok)
 
-	err := rt.Put("/", n0)
+	err := rt.PutAPI(API{URLPattern: "/", Method: n0})
 	assert.Error(t, err, "Method GET already exists in path /")
 
 	n1 := getMockMethod(config.MethodPost)
-	err = rt.Put("/mock", n0)
+	err = rt.PutAPI(API{URLPattern: "/mock", Method: n0})
 	assert.Nil(t, err)
-	err = rt.Put("/mock", n1)
+	err = rt.PutAPI(API{URLPattern: "/mock", Method: n1})
 	assert.Nil(t, err)
 	mNode, ok := rt.tree.Get("/mock")
 	assert.True(t, ok)
 	assert.Equal(t, len(mNode.(*Node).methods), 2)
 
-	err = rt.Put("/mock/test", n0)
+	err = rt.PutAPI(API{URLPattern: "/mock/test", Method: n0})
 	assert.Nil(t, err)
-	_, ok = rt.tree.Get("/mock")
+	_, ok = rt.tree.Get("/mock/test")
 	assert.True(t, ok)
 
-	rt.Put("/test/:id", n0)
+	rt.PutAPI(API{URLPattern: "/test/:id", Method: n0})
 	tNode, ok := rt.tree.Get("/test/:id")
 	assert.True(t, ok)
 	assert.True(t, tNode.(*Node).wildcard)
 
-	err = rt.Put("/test/:id", n1)
+	err = rt.PutAPI(API{URLPattern: "/test/:id", Method: n1})
 	assert.Nil(t, err)
-	err = rt.Put("/test/js", n0)
+	err = rt.PutAPI(API{URLPattern: "/test/js", Method: n0})
 	assert.Error(t, err, "/test/:id wildcard already exist so that cannot add path /test/js")
 
-	err = rt.Put("/test/:id/mock", n0)
+	err = rt.PutAPI(API{URLPattern: "/test/:id/mock", Method: n0})
 	tNode, ok = rt.tree.Get("/test/:id/mock")
 	assert.True(t, ok)
 	assert.True(t, tNode.(*Node).wildcard)
@@ -92,28 +92,31 @@ func TestFindMethod(t *testing.T) {
 	}
 	n0 := getMockMethod(config.MethodGet)
 	n1 := getMockMethod(config.MethodPost)
-	e := rt.Put("/theboys", n0)
+	e := rt.PutAPI(API{URLPattern: "/theboys", Method: n0})
 	assert.Nil(t, e)
-	e = rt.Put("/theboys/:id", n0)
+	e = rt.PutAPI(API{URLPattern: "/theboys/:id", Method: n0})
 	assert.Nil(t, e)
-	e = rt.Put("/vought/:id/supe/:name", n1)
+	e = rt.PutAPI(API{URLPattern: "/vought/:id/supe/:name", Method: n1})
 	assert.Nil(t, e)
 
-	m, ok := rt.FindMethod("/theboys", config.MethodGet)
+	m, ok := rt.FindAPI("/theboys", config.MethodGet)
 	assert.True(t, ok)
 	assert.NotNil(t, m)
+	assert.Equal(t, m.URLPattern, "/theboys")
 
-	m, ok = rt.FindMethod("/theboys", config.MethodPost)
+	m, ok = rt.FindAPI("/theboys", config.MethodPost)
 	assert.False(t, ok)
 	assert.Nil(t, m)
 
-	m, ok = rt.FindMethod("/vought/爱国者/supe/startlight", config.MethodPost)
+	m, ok = rt.FindAPI("/vought/爱国者/supe/startlight", config.MethodPost)
 	assert.True(t, ok)
 	assert.NotNil(t, m)
+	assert.Equal(t, m.URLPattern, "/vought/:id/supe/:name")
 
-	m, ok = rt.FindMethod("/vought/123/supe/startlight", config.MethodPost)
+	m, ok = rt.FindAPI("/vought/123/supe/startlight", config.MethodPost)
 	assert.True(t, ok)
 	assert.NotNil(t, m)
+	assert.Equal(t, m.URLPattern, "/vought/:id/supe/:name")
 }
 
 func TestUpdateMethod(t *testing.T) {
@@ -123,19 +126,19 @@ func TestUpdateMethod(t *testing.T) {
 	m1.Version = "2.0.0"
 
 	rt := NewRoute()
-	rt.Put("/marvel", m0)
-	m, _ := rt.FindMethod("/marvel", config.MethodGet)
+	rt.PutAPI(API{URLPattern: "/marvel", Method: m0})
+	m, _ := rt.FindAPI("/marvel", config.MethodGet)
 	assert.Equal(t, m.Version, "1.0.0")
-	rt.UpdateMethod("/marvel", config.MethodGet, m1)
-	m, ok := rt.FindMethod("/marvel", config.MethodGet)
+	rt.UpdateAPI(API{URLPattern: "/marvel", Method: m1})
+	m, ok := rt.FindAPI("/marvel", config.MethodGet)
 	assert.True(t, ok)
 	assert.Equal(t, m.Version, "2.0.0")
 
-	rt.Put("/theboys/:id", m0)
-	m, _ = rt.FindMethod("/theBoys/12345", config.MethodGet)
+	rt.PutAPI(API{URLPattern: "/theboys/:id", Method: m0})
+	m, _ = rt.FindAPI("/theBoys/12345", config.MethodGet)
 	assert.Equal(t, m.Version, "1.0.0")
-	rt.UpdateMethod("/theBoys/:id", config.MethodGet, m1)
-	m, ok = rt.FindMethod("/theBoys/12345", config.MethodGet)
+	rt.UpdateAPI(API{URLPattern: "/theBoys/:id", Method: m1})
+	m, ok = rt.FindAPI("/theBoys/12345", config.MethodGet)
 	assert.True(t, ok)
 	assert.Equal(t, m.Version, "2.0.0")
 }
@@ -146,11 +149,11 @@ func TestSearchWildcard(t *testing.T) {
 		wildcardTree: avltree.NewWithStringComparator(),
 	}
 	n0 := getMockMethod(config.MethodGet)
-	e := rt.Put("/theboys", n0)
+	e := rt.PutAPI(API{URLPattern: "/theboys", Method: n0})
 	assert.Nil(t, e)
-	e = rt.Put("/theboys/:id", n0)
+	e = rt.PutAPI(API{URLPattern: "/theboys/:id", Method: n0})
 	assert.Nil(t, e)
-	e = rt.Put("/vought/:id/supe/:name", n0)
+	e = rt.PutAPI(API{URLPattern: "/vought/:id/supe/:name", Method: n0})
 	assert.Nil(t, e)
 
 	_, ok := rt.searchWildcard("/marvel")
@@ -168,4 +171,23 @@ func TestWildcardMatch(t *testing.T) {
 	assert.True(t, wildcardMatch("/vought/:id", "/vought/125abc"))
 	assert.False(t, wildcardMatch("/vought/:id", "/vought/1234abcd/status"))
 	assert.True(t, wildcardMatch("/voughT/:id/:action", "/Vought/1234abcd/attack"))
+}
+
+func TestPutResource(t *testing.T) {
+	rt := NewRoute()
+	err := rt.PutResource()
+	assert.Nil(t, err)
+}
+
+func TestGetFilters(t *testing.T) {
+	rt := NewRoute()
+	n0 := getMockMethod(config.MethodGet)
+	n1 := getMockMethod(config.MethodPost)
+	e := rt.PutAPI(API{URLPattern: "/theboys", Method: n0})
+	assert.Nil(t, e)
+	e = rt.PutAPI(API{URLPattern: "/theboys/:id", Method: n0})
+	assert.Nil(t, e)
+	e = rt.PutAPI(API{URLPattern: "/vought/:id/supe/:name", Method: n1})
+	assert.Nil(t, e)
+
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -107,6 +107,10 @@ func TestFindMethod(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, m)
 
+	m, ok = rt.FindMethod("/vought/爱国者/supe/startlight", config.MethodPost)
+	assert.True(t, ok)
+	assert.NotNil(t, m)
+
 	m, ok = rt.FindMethod("/vought/123/supe/startlight", config.MethodPost)
 	assert.True(t, ok)
 	assert.NotNil(t, m)

--- a/pkg/service/api.go
+++ b/pkg/service/api.go
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+)
+
+// API describes the minimum configuration of an RESTful api configure in gateway
+type API struct {
+	URLPattern    string `json:"urlPattern" yaml:"urlPattern"`
+	config.Method `json:"method,inline" yaml:"method,inline"`
+}

--- a/pkg/service/api/discovery_service.go
+++ b/pkg/service/api/discovery_service.go
@@ -98,17 +98,17 @@ func (ads *LocalMemoryAPIDiscoveryService) GetApi(request service.DiscoveryReque
 }
 
 // AddAPI adds a method to the router tree
-func (ads *LocalMemoryAPIDiscoveryService) AddAPI(api service.API) error {
-	return ads.router.Put(api.URLPattern, api.Method)
+func (ads *LocalMemoryAPIDiscoveryService) AddAPI(api router.API) error {
+	return ads.router.PutAPI(api)
 }
 
 // GetAPI returns the method to the caller
-func (ads *LocalMemoryAPIDiscoveryService) GetAPI(url string, httpVerb config.HTTPVerb) (service.DiscoveryResponse, error) {
-	if method, ok := ads.router.FindMethod(url, httpVerb); ok {
-		return *service.NewDiscoveryResponse(method), nil
+func (ads *LocalMemoryAPIDiscoveryService) GetAPI(url string, httpVerb config.HTTPVerb) (router.API, error) {
+	if api, ok := ads.router.FindAPI(url, httpVerb); ok {
+		return *api, nil
 	}
 
-	return *service.EmptyDiscoveryResponse, errors.New("not found")
+	return router.API{}, errors.New("not found")
 }
 
 // InitAPIsFromConfig inits the router from API config and to local cache
@@ -154,7 +154,7 @@ func loadAPIFromResource(parrentPath string, resources []config.Resource, localS
 func loadAPIFromMethods(fullPath string, methods []config.Method, localSrv service.ApiDiscoveryService) error {
 	errStack := []string{}
 	for _, method := range methods {
-		api := service.API{
+		api := router.API{
 			URLPattern: fullPath,
 			Method:     method,
 		}

--- a/pkg/service/api/discovery_service.go
+++ b/pkg/service/api/discovery_service.go
@@ -19,34 +19,44 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 import (
 	"github.com/goinggo/mapstructure"
+	"github.com/pkg/errors"
 )
 
 import (
+	"fmt"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/client/dubbo"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/logger"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/model"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/service"
+	"strings"
 )
 
 func init() {
-	extension.SetApiDiscoveryService(constant.LocalMemoryApiDiscoveryService, NewLocalMemoryApiDiscoveryService())
+	extension.SetApiDiscoveryService(constant.LocalMemoryApiDiscoveryService, NewLocalMemoryAPIDiscoveryService())
 }
 
-type LocalMemoryApiDiscoveryService struct {
+// LocalMemoryAPIDiscoveryService is the local cached API discovery service
+type LocalMemoryAPIDiscoveryService struct {
+	router *router.Route
 }
 
-func NewLocalMemoryApiDiscoveryService() *LocalMemoryApiDiscoveryService {
-	return &LocalMemoryApiDiscoveryService{}
+// NewLocalMemoryAPIDiscoveryService creates a new LocalMemoryApiDiscoveryService instance
+func NewLocalMemoryAPIDiscoveryService() *LocalMemoryAPIDiscoveryService {
+	return &LocalMemoryAPIDiscoveryService{
+		router: router.NewRoute(),
+	}
 }
 
-func (ads *LocalMemoryApiDiscoveryService) AddApi(request service.DiscoveryRequest) (service.DiscoveryResponse, error) {
+// AddApi adds a method to the router tree
+func (ads *LocalMemoryAPIDiscoveryService) AddApi(request service.DiscoveryRequest) (service.DiscoveryResponse, error) {
 	aj := model.NewApi()
 	if err := json.Unmarshal(request.Body, aj); err != nil {
 		return *service.EmptyDiscoveryResponse, err
@@ -77,7 +87,7 @@ func (ads *LocalMemoryApiDiscoveryService) AddApi(request service.DiscoveryReque
 	return *service.NewDiscoveryResponseWithSuccess(true), nil
 }
 
-func (ads *LocalMemoryApiDiscoveryService) GetApi(request service.DiscoveryRequest) (service.DiscoveryResponse, error) {
+func (ads *LocalMemoryAPIDiscoveryService) GetApi(request service.DiscoveryRequest) (service.DiscoveryResponse, error) {
 	n := string(request.Body)
 
 	if a, ok := model.CacheApi.Load(n); ok {
@@ -85,4 +95,75 @@ func (ads *LocalMemoryApiDiscoveryService) GetApi(request service.DiscoveryReque
 	}
 
 	return *service.EmptyDiscoveryResponse, errors.New("not found")
+}
+
+// AddAPI adds a method to the router tree
+func (ads *LocalMemoryAPIDiscoveryService) AddAPI(api service.API) error {
+	return ads.router.Put(api.URLPattern, api.Method)
+}
+
+// GetAPI returns the method to the caller
+func (ads *LocalMemoryAPIDiscoveryService) GetAPI(url string, httpVerb config.HTTPVerb) (service.DiscoveryResponse, error) {
+	if method, ok := ads.router.FindMethod(url, httpVerb); ok {
+		return *service.NewDiscoveryResponse(method), nil
+	}
+
+	return *service.EmptyDiscoveryResponse, errors.New("not found")
+}
+
+// InitAPIsFromConfig inits the router from API config and to local cache
+func InitAPIsFromConfig(apiConfig *config.APIConfig) error {
+	localAPIDiscSrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	if len(apiConfig.Resources) == 0 {
+		return nil
+	}
+	return loadAPIFromResource("", apiConfig.Resources, localAPIDiscSrv)
+}
+
+func loadAPIFromResource(parrentPath string, resources []config.Resource, localSrv service.ApiDiscoveryService) error {
+	errStack := []string{}
+	if len(resources) == 0 {
+		return nil
+	}
+	groupPath := parrentPath
+	if parrentPath == constant.PathSlash {
+		groupPath = ""
+	}
+	for _, resource := range resources {
+		fullPath := groupPath + resource.Path
+		if !strings.HasPrefix(resource.Path, constant.PathSlash) {
+			errStack = append(errStack, fmt.Sprintf("Path %s in %s doesn't start with /", resource.Path, parrentPath))
+			continue
+		}
+		if len(resource.Resources) > 0 {
+			if err := loadAPIFromResource(resource.Path, resource.Resources, localSrv); err != nil {
+				errStack = append(errStack, err.Error())
+			}
+		}
+
+		if err := loadAPIFromMethods(fullPath, resource.Methods, localSrv); err != nil {
+			errStack = append(errStack, err.Error())
+		}
+	}
+	if len(errStack) > 0 {
+		return errors.New(strings.Join(errStack, "; "))
+	}
+	return nil
+}
+
+func loadAPIFromMethods(fullPath string, methods []config.Method, localSrv service.ApiDiscoveryService) error {
+	errStack := []string{}
+	for _, method := range methods {
+		api := service.API{
+			URLPattern: fullPath,
+			Method:     method,
+		}
+		if err := localSrv.AddAPI(api); err != nil {
+			errStack = append(errStack, fmt.Sprintf("Path: %s, Method: %s, error: %s", fullPath, method.HTTPVerb, err.Error()))
+		}
+	}
+	if len(errStack) > 0 {
+		return errors.New(strings.Join(errStack, "\n"))
+	}
+	return nil
 }

--- a/pkg/service/api/discovery_service_test.go
+++ b/pkg/service/api/discovery_service_test.go
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/extension"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/service"
+)
+
+func getMockAPI(urlPattern string, verb config.HTTPVerb) service.API {
+	inbound := config.InboundRequest{}
+	integration := config.IntegrationRequest{}
+	method := config.Method{
+		OnAir:              true,
+		HTTPVerb:           verb,
+		InboundRequest:     inbound,
+		IntegrationRequest: integration,
+	}
+	return service.API{
+		URLPattern: urlPattern,
+		Method:     method,
+	}
+}
+
+func TestNewLocalMemoryAPIDiscoveryService(t *testing.T) {
+	l := NewLocalMemoryAPIDiscoveryService()
+	assert.NotNil(t, l)
+	assert.NotNil(t, l.router)
+}
+
+func TestAddAPI(t *testing.T) {
+	l := NewLocalMemoryAPIDiscoveryService()
+	err := l.AddAPI(getMockAPI("/this/is/test", config.MethodPut))
+	assert.Nil(t, err)
+	_, found := l.router.FindMethod("/this/is/test", config.MethodPut)
+	assert.True(t, found)
+}
+
+func TestGetAPI(t *testing.T) {
+	l := NewLocalMemoryAPIDiscoveryService()
+	err := l.AddAPI(getMockAPI("/this/is/test", config.MethodPut))
+	assert.Nil(t, err)
+	_, err = l.GetAPI("/this/is/test", config.MethodPut)
+	assert.Nil(t, err)
+
+	_, err = l.GetAPI("/this/is/test/or/else", config.MethodPut)
+	assert.NotNil(t, err)
+}
+
+func TestLoadAPI(t *testing.T) {
+	apiC, err := config.LoadAPIConfigFromFile("../../config/mock/api_config.yml")
+	assert.Empty(t, err)
+	err = InitAPIsFromConfig(apiC)
+	assert.Nil(t, err)
+	apiDisSrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	rsp, err := apiDisSrv.GetAPI("/", config.MethodGet)
+	assert.True(t, rsp.Success)
+	rsp, err = apiDisSrv.GetAPI("/mockTest", config.MethodGet)
+	assert.True(t, rsp.Success)
+	rsp, err = apiDisSrv.GetAPI("/mockTest", config.MethodPost)
+	assert.True(t, rsp.Success)
+	rsp, err = apiDisSrv.GetAPI("/mockTest/12345", config.MethodGet)
+	assert.True(t, rsp.Success)
+}
+
+func TestLoadAPIFromResource(t *testing.T) {
+	apiDiscSrv := NewLocalMemoryAPIDiscoveryService()
+	mockMethod1 := getMockAPI("", config.MethodPut).Method
+	mockMethod2 := getMockAPI("", config.MethodPost).Method
+	mockMethod3 := getMockAPI("", config.MethodGet).Method
+	tempResources := []config.Resource{
+		{
+			Type:        "Restful",
+			Path:        "/",
+			Description: "test only",
+			Methods: []config.Method{
+				mockMethod1,
+				mockMethod2,
+				mockMethod3,
+			},
+			Resources: []config.Resource{
+				{
+					Type:        "Restful",
+					Path:        "/mock",
+					Description: "test only",
+					Methods: []config.Method{
+						mockMethod1,
+						mockMethod2,
+						mockMethod3,
+					},
+				},
+				{
+					Type:        "Restful",
+					Path:        "/mock2",
+					Description: "test only",
+					Methods: []config.Method{
+						mockMethod1,
+					},
+					Resources: []config.Resource{
+						{
+							Type:        "Restful",
+							Path:        "/:id",
+							Description: "test only",
+							Methods: []config.Method{
+								mockMethod1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := loadAPIFromResource("", tempResources, apiDiscSrv)
+	assert.Nil(t, err)
+	rsp, _ := apiDiscSrv.GetAPI("/", config.MethodPut)
+	assert.True(t, rsp.Success)
+	rsp, _ = apiDiscSrv.GetAPI("/", config.MethodGet)
+	assert.True(t, rsp.Success)
+	rsp, _ = apiDiscSrv.GetAPI("/mock", config.MethodGet)
+	assert.True(t, rsp.Success)
+	rsp, _ = apiDiscSrv.GetAPI("/mock2/12345", config.MethodPut)
+	assert.True(t, rsp.Success)
+
+	tempResources = []config.Resource{
+		{
+			Type:        "Restful",
+			Path:        "/mock",
+			Description: "test only",
+			Methods: []config.Method{
+				mockMethod1,
+			},
+			Resources: []config.Resource{
+				{
+					Type:        "Restful",
+					Path:        ":id",
+					Description: "test only",
+					Methods: []config.Method{
+						mockMethod1,
+					},
+				},
+				{
+					Type:        "Restful",
+					Path:        ":ik",
+					Description: "test only",
+					Methods: []config.Method{
+						mockMethod1,
+					},
+				},
+			},
+		},
+	}
+	apiDiscSrv = NewLocalMemoryAPIDiscoveryService()
+	err = loadAPIFromResource("", tempResources, apiDiscSrv)
+	assert.EqualError(t, err, "Path :id in /mock doesn't start with /; Path :ik in /mock doesn't start with /")
+}
+
+func TestLoadAPIFromMethods(t *testing.T) {
+	tempMethods := []config.Method{
+		getMockAPI("", config.MethodPut).Method,
+		getMockAPI("", config.MethodGet).Method,
+		getMockAPI("", config.MethodPut).Method,
+	}
+	apiDiscSrv := NewLocalMemoryAPIDiscoveryService()
+	err := loadAPIFromMethods("/mock", tempMethods, apiDiscSrv)
+	rsp, _ := apiDiscSrv.GetAPI("/mock", config.MethodPut)
+	assert.True(t, rsp.Success)
+	rsp, _ = apiDiscSrv.GetAPI("/mock", config.MethodGet)
+	assert.True(t, rsp.Success)
+	assert.EqualError(t, err, "Path: /mock, Method: PUT, error: Method PUT already exists in path /mock")
+}

--- a/pkg/service/api/discovery_service_test.go
+++ b/pkg/service/api/discovery_service_test.go
@@ -75,9 +75,9 @@ func TestGetAPI(t *testing.T) {
 func TestLoadAPI(t *testing.T) {
 	apiC, err := config.LoadAPIConfigFromFile("../../config/mock/api_config.yml")
 	assert.Empty(t, err)
-	err = InitAPIsFromConfig(apiC)
+	err = InitAPIsFromConfig(*apiC)
 	assert.Nil(t, err)
-	apiDisSrv := extension.GetMustApiDiscoveryService(constant.LocalMemoryApiDiscoveryService)
+	apiDisSrv := extension.GetMustAPIDiscoveryService(constant.LocalMemoryApiDiscoveryService)
 	rsp, err := apiDisSrv.GetAPI("/", config.MethodGet)
 	assert.NotNil(t, rsp.URLPattern)
 	rsp, err = apiDisSrv.GetAPI("/mockTest", config.MethodGet)

--- a/pkg/service/discovery_service.go
+++ b/pkg/service/discovery_service.go
@@ -17,6 +17,10 @@
 
 package service
 
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+)
+
 // DiscoveryRequest a request for discovery
 type DiscoveryRequest struct {
 	Body []byte
@@ -56,6 +60,8 @@ var EmptyDiscoveryResponse = &DiscoveryResponse{}
 type ApiDiscoveryService interface {
 	AddApi(request DiscoveryRequest) (DiscoveryResponse, error)
 	GetApi(request DiscoveryRequest) (DiscoveryResponse, error)
+	AddAPI(API) error
+	GetAPI(string, config.HTTPVerb) (DiscoveryResponse, error)
 }
 
 // DiscoveryService is come from envoy, it can used for admin

--- a/pkg/service/discovery_service.go
+++ b/pkg/service/discovery_service.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/router"
 )
 
 // DiscoveryRequest a request for discovery
@@ -60,8 +61,8 @@ var EmptyDiscoveryResponse = &DiscoveryResponse{}
 type ApiDiscoveryService interface {
 	AddApi(request DiscoveryRequest) (DiscoveryResponse, error)
 	GetApi(request DiscoveryRequest) (DiscoveryResponse, error)
-	AddAPI(API) error
-	GetAPI(string, config.HTTPVerb) (DiscoveryResponse, error)
+	AddAPI(router.API) error
+	GetAPI(string, config.HTTPVerb) (router.API, error)
 }
 
 // DiscoveryService is come from envoy, it can used for admin

--- a/pkg/service/discovery_service.go
+++ b/pkg/service/discovery_service.go
@@ -57,10 +57,8 @@ func NewDiscoveryResponse(d interface{}) *DiscoveryResponse {
 
 var EmptyDiscoveryResponse = &DiscoveryResponse{}
 
-// ApiDiscoveryService api discovery service interface
-type ApiDiscoveryService interface {
-	AddApi(request DiscoveryRequest) (DiscoveryResponse, error)
-	GetApi(request DiscoveryRequest) (DiscoveryResponse, error)
+// APIDiscoveryService api discovery service interface
+type APIDiscoveryService interface {
 	AddAPI(router.API) error
 	GetAPI(string, config.HTTPVerb) (router.API, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

0. Load the API config into the local memory API discovery service

as described in [this flow chart](https://cdn.nlark.com/yuque/0/2020/png/327432/1601110962319-3bcd8c32-0ae1-4248-8c51-ce7b25c53769.png?x-oss-process=image%2Fresize%2Cw_1492)

1. Implement the API router for the RESTful API server to match the inbound request to proper API in proxy/listener.go.
2. handle invoke the matched API with the inbound mapped parameters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```