### PR TITLE
Feature/http 2 http param mapping

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,11 +17,12 @@
 
 package client
 
+// Client represents the interface of http/dubbo clients
 type Client interface {
 	Init() error
 	Close() error
 	Call(req *Request) (resp Response, err error)
 
-	// MappingParams mapping param, uri, query, body ...
-	MappingParams(req *Request) (types []string, reqData []interface{}, err error)
+	// MapParams mapping param, uri, query, body ...
+	MapParams(req *Request) (reqData interface{}, err error)
 }

--- a/pkg/client/dubbo/dubbo.go
+++ b/pkg/client/dubbo/dubbo.go
@@ -19,7 +19,6 @@ package dubbo
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -29,7 +28,6 @@ import (
 	"github.com/apache/dubbo-go/common/constant"
 	dg "github.com/apache/dubbo-go/config"
 	"github.com/apache/dubbo-go/protocol/dubbo"
-	"github.com/pkg/errors"
 )
 
 import (
@@ -43,12 +41,6 @@ const (
 	JavaStringClassName = "java.lang.String"
 	JavaLangClassName   = "java.lang.Long"
 )
-
-var mappers = map[string]client.ParamMapper{
-	"queryStrings": queryStringsMapper{},
-	"headers":      headerMapper{},
-	"requestBody":  bodyMapper{},
-}
 
 var (
 	dubboClient        *Client
@@ -140,11 +132,11 @@ func (dc *Client) Close() error {
 // Call invoke service
 func (dc *Client) Call(req *client.Request) (resp client.Response, err error) {
 	dm := req.API.Method.IntegrationRequest
-	types, values, err := dc.MappingParams(req)
+	types := req.API.IntegrationRequest.ParamTypes
+	values, err := dc.MapParams(req)
 	if err != nil {
 		return *client.EmptyResponse, err
 	}
-
 	method := dm.Method
 	logger.Debugf("[dubbo-go-proxy] invoke, method:%s, types:%s, reqData:%v", method, types, values)
 
@@ -165,22 +157,22 @@ func (dc *Client) Call(req *client.Request) (resp client.Response, err error) {
 	return *NewDubboResponse(rst), nil
 }
 
-// MappingParams param mapping to api.
-func (dc *Client) MappingParams(req *client.Request) ([]string, []interface{}, error) {
+// MapParams param mapping to api.
+func (dc *Client) MapParams(req *client.Request) (interface{}, error) {
 	r := req.API.Method.IntegrationRequest
 	var values []interface{}
 	for _, mappingParam := range r.MappingParams {
 		source, _, err := client.ParseMapSource(mappingParam.Name)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if mapper, ok := mappers[source]; ok {
 			if err := mapper.Map(mappingParam, *req, &values); err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 		}
 	}
-	return req.API.IntegrationRequest.ParamTypes, values, nil
+	return values, nil
 }
 
 func (dc *Client) get(key string) *dg.GenericService {
@@ -245,31 +237,4 @@ func (dc *Client) create(key string, irequest config.IntegrationRequest) *dg.Gen
 
 	dc.GenericServicePool[key] = clientService
 	return clientService
-}
-
-func validateTarget(target interface{}) (reflect.Value, error) {
-	rv := reflect.ValueOf(target)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
-		return rv, errors.New("Target params must be a non-nil pointer")
-	}
-	if _, ok := target.(*[]interface{}); !ok {
-		return rv, errors.New("Target params for dubbo backend must be *[]interface{}")
-	}
-	return rv, nil
-}
-
-func setTarget(rv reflect.Value, pos int, value interface{}) {
-	if rv.Kind() != reflect.Ptr && rv.Type().Name() != "" && rv.CanAddr() {
-		rv = rv.Addr()
-	} else {
-		rv = rv.Elem()
-	}
-
-	tempValue := rv.Interface().([]interface{})
-	if len(tempValue) <= pos {
-		list := make([]interface{}, pos+1-len(tempValue))
-		tempValue = append(tempValue, list...)
-	}
-	tempValue[pos] = value
-	rv.Set(reflect.ValueOf(tempValue))
 }

--- a/pkg/client/dubbo/dubbo.go
+++ b/pkg/client/dubbo/dubbo.go
@@ -154,7 +154,7 @@ func (dc *Client) Call(req *client.Request) (res interface{}, err error) {
 	return rst, nil
 }
 
-// MapParams param mapping to api.
+// MapParams params mapping to api.
 func (dc *Client) MapParams(req *client.Request) (interface{}, error) {
 	r := req.API.Method.IntegrationRequest
 	var values []interface{}
@@ -164,7 +164,7 @@ func (dc *Client) MapParams(req *client.Request) (interface{}, error) {
 			return nil, err
 		}
 		if mapper, ok := mappers[source]; ok {
-			if err := mapper.Map(mappingParam, *req, &values); err != nil {
+			if err := mapper.Map(mappingParam, req, &values); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/client/dubbo/dubbo_test.go
+++ b/pkg/client/dubbo/dubbo_test.go
@@ -104,10 +104,10 @@ func TestMappingParams(t *testing.T) {
 		},
 	}
 	req := client.NewReq(context.TODO(), r, api)
-	_, params, err := dClient.MappingParams(req)
+	params, err := dClient.MapParams(req)
 	assert.Nil(t, err)
-	assert.Equal(t, params[0], "12345")
-	assert.Equal(t, params[1], "19")
+	assert.Equal(t, params.([]interface{})[0], "12345")
+	assert.Equal(t, params.([]interface{})[1], "19")
 
 	r, _ = http.NewRequest("GET", "/mock/test?id=12345&age=19", bytes.NewReader([]byte("")))
 	api = mock.GetMockAPI(config.MethodGet, "/mock/test")
@@ -127,11 +127,11 @@ func TestMappingParams(t *testing.T) {
 	}
 	r.Header.Set("Auth", "1234567")
 	req = client.NewReq(context.TODO(), r, api)
-	_, params, err = dClient.MappingParams(req)
+	params, err = dClient.MapParams(req)
 	assert.Nil(t, err)
-	assert.Equal(t, params[0], "12345")
-	assert.Equal(t, params[1], "19")
-	assert.Equal(t, params[2], "1234567")
+	assert.Equal(t, params.([]interface{})[0], "12345")
+	assert.Equal(t, params.([]interface{})[1], "19")
+	assert.Equal(t, params.([]interface{})[2], "1234567")
 
 	r, _ = http.NewRequest("POST", "/mock/test?id=12345&age=19", bytes.NewReader([]byte(`{"sex": "male", "name":{"firstName": "Joe", "lastName": "Biden"}}`)))
 	api = mock.GetMockAPI(config.MethodGet, "/mock/test")
@@ -159,46 +159,11 @@ func TestMappingParams(t *testing.T) {
 	}
 	r.Header.Set("Auth", "1234567")
 	req = client.NewReq(context.TODO(), r, api)
-	_, params, err = dClient.MappingParams(req)
+	params, err = dClient.MapParams(req)
 	assert.Nil(t, err)
-	assert.Equal(t, params[0], "12345")
-	assert.Equal(t, params[1], "19")
-	assert.Equal(t, params[2], "1234567")
-	assert.Equal(t, params[3], "male")
-	assert.Equal(t, params[4], "Joe")
-}
-
-func TestValidateTarget(t *testing.T) {
-	target := []interface{}{}
-	val, err := validateTarget(&target)
-	assert.Nil(t, err)
-	assert.NotNil(t, val)
-	_, err = validateTarget(target)
-	assert.EqualError(t, err, "Target params must be a non-nil pointer")
-	target2 := ""
-	_, err = validateTarget(&target2)
-	assert.EqualError(t, err, "Target params for dubbo backend must be *[]interface{}")
-}
-
-func TestParseMapSource(t *testing.T) {
-	from, key, err := client.ParseMapSource("queryStrings.id")
-	assert.Nil(t, err)
-	assert.Equal(t, from, "queryStrings")
-	assert.Equal(t, key[0], "id")
-
-	from, key, err = client.ParseMapSource("headers.id")
-	assert.Nil(t, err)
-	assert.Equal(t, from, "headers")
-	assert.Equal(t, key[0], "id")
-
-	from, key, err = client.ParseMapSource("requestBody.user.id")
-	assert.Nil(t, err)
-	assert.Equal(t, from, "requestBody")
-	assert.Equal(t, key[0], "user")
-	assert.Equal(t, key[1], "id")
-
-	from, key, err = client.ParseMapSource("what.user.id")
-	assert.EqualError(t, err, "Parameter mapping config incorrect. Please fix it")
-	from, key, err = client.ParseMapSource("requestBody.*userid")
-	assert.EqualError(t, err, "Parameter mapping config incorrect. Please fix it")
+	assert.Equal(t, params.([]interface{})[0], "12345")
+	assert.Equal(t, params.([]interface{})[1], "19")
+	assert.Equal(t, params.([]interface{})[2], "1234567")
+	assert.Equal(t, params.([]interface{})[3], "male")
+	assert.Equal(t, params.([]interface{})[4], "Joe")
 }

--- a/pkg/client/dubbo/mapper.go
+++ b/pkg/client/dubbo/mapper.go
@@ -19,6 +19,7 @@ package dubbo
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/url"
 	"reflect"
@@ -30,7 +31,6 @@ import (
 )
 
 import (
-	"encoding/json"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
@@ -45,6 +45,7 @@ var mappers = map[string]client.ParamMapper{
 
 type queryStringsMapper struct{}
 
+// nolint
 func (qm queryStringsMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {
@@ -74,6 +75,7 @@ func (qm queryStringsMapper) Map(mp config.MappingParam, c client.Request, targe
 
 type headerMapper struct{}
 
+// nolint
 func (hm headerMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {
@@ -94,6 +96,7 @@ func (hm headerMapper) Map(mp config.MappingParam, c client.Request, target inte
 
 type bodyMapper struct{}
 
+// nolint
 func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
 	// TO-DO: add support for content-type other than application/json
 	rv, err := validateTarget(target)
@@ -127,6 +130,7 @@ func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, target interf
 
 type uriMapper struct{}
 
+// nolint
 func (um uriMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {

--- a/pkg/client/dubbo/mapper.go
+++ b/pkg/client/dubbo/mapper.go
@@ -46,7 +46,7 @@ var mappers = map[string]client.ParamMapper{
 type queryStringsMapper struct{}
 
 // nolint
-func (qm queryStringsMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
+func (qm queryStringsMapper) Map(mp config.MappingParam, c *client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (qm queryStringsMapper) Map(mp config.MappingParam, c client.Request, targe
 type headerMapper struct{}
 
 // nolint
-func (hm headerMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
+func (hm headerMapper) Map(mp config.MappingParam, c *client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (hm headerMapper) Map(mp config.MappingParam, c client.Request, target inte
 type bodyMapper struct{}
 
 // nolint
-func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
+func (bm bodyMapper) Map(mp config.MappingParam, c *client.Request, target interface{}) error {
 	// TO-DO: add support for content-type other than application/json
 	rv, err := validateTarget(target)
 	if err != nil {
@@ -131,7 +131,7 @@ func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, target interf
 type uriMapper struct{}
 
 // nolint
-func (um uriMapper) Map(mp config.MappingParam, c client.Request, target interface{}) error {
+func (um uriMapper) Map(mp config.MappingParam, c *client.Request, target interface{}) error {
 	rv, err := validateTarget(target)
 	if err != nil {
 		return err

--- a/pkg/client/dubbo/mapper_test.go
+++ b/pkg/client/dubbo/mapper_test.go
@@ -122,6 +122,10 @@ func TestBodyMapper(t *testing.T) {
 			Name:  "requestBody.name.lastName",
 			MapTo: "1",
 		},
+		{
+			Name:  "requestBody.name",
+			MapTo: "2",
+		},
 	}
 	bm := bodyMapper{}
 	target := []interface{}{}
@@ -134,4 +138,20 @@ func TestBodyMapper(t *testing.T) {
 	err = bm.Map(api.IntegrationRequest.MappingParams[1], *req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[1], "Biden")
+
+	err = bm.Map(api.IntegrationRequest.MappingParams[2], *req, &target)
+	assert.Nil(t, err)
+	assert.Equal(t, target[2], map[string]interface{}(map[string]interface{}{"firstName": "Joe", "lastName": "Biden"}))
+}
+
+func TestValidateTarget(t *testing.T) {
+	target := []interface{}{}
+	val, err := validateTarget(&target)
+	assert.Nil(t, err)
+	assert.NotNil(t, val)
+	_, err = validateTarget(target)
+	assert.EqualError(t, err, "Target params must be a non-nil pointer")
+	target2 := ""
+	_, err = validateTarget(&target2)
+	assert.EqualError(t, err, "Target params for dubbo backend must be *[]interface{}")
 }

--- a/pkg/client/dubbo/mapper_test.go
+++ b/pkg/client/dubbo/mapper_test.go
@@ -55,12 +55,12 @@ func TestQueryStringsMapper(t *testing.T) {
 
 	params := []interface{}{}
 	qs := queryStringsMapper{}
-	err := qs.Map(api.IntegrationRequest.MappingParams[0], *req, &params)
+	err := qs.Map(api.IntegrationRequest.MappingParams[0], req, &params)
 	assert.Nil(t, err)
 	assert.Equal(t, params[0], "12345")
-	err = qs.Map(api.IntegrationRequest.MappingParams[1], *req, &params)
+	err = qs.Map(api.IntegrationRequest.MappingParams[1], req, &params)
 	assert.EqualError(t, err, "Query parameter [name] does not exist")
-	err = qs.Map(api.IntegrationRequest.MappingParams[2], *req, &params)
+	err = qs.Map(api.IntegrationRequest.MappingParams[2], req, &params)
 	assert.EqualError(t, err, "Parameter mapping {queryStrings.age jk} incorrect")
 
 	r, _ = http.NewRequest("GET", "/mock/test?id=12345&age=19", bytes.NewReader([]byte("")))
@@ -77,11 +77,11 @@ func TestQueryStringsMapper(t *testing.T) {
 	}
 	req = client.NewReq(context.TODO(), r, api)
 	params = []interface{}{}
-	err = qs.Map(api.IntegrationRequest.MappingParams[0], *req, &params)
+	err = qs.Map(api.IntegrationRequest.MappingParams[0], req, &params)
 	assert.Nil(t, err)
 	assert.Equal(t, params[1], "12345")
 	assert.Nil(t, params[0])
-	err = qs.Map(api.IntegrationRequest.MappingParams[1], *req, &params)
+	err = qs.Map(api.IntegrationRequest.MappingParams[1], req, &params)
 	assert.Nil(t, err)
 	assert.Equal(t, params[1], "12345")
 	assert.Equal(t, params[0], "19")
@@ -101,11 +101,11 @@ func TestHeaderMapper(t *testing.T) {
 	target := []interface{}{}
 	req := client.NewReq(context.TODO(), r, api)
 
-	err := hm.Map(api.IntegrationRequest.MappingParams[0], *req, &target)
+	err := hm.Map(api.IntegrationRequest.MappingParams[0], req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[0], "1234567")
 
-	err = hm.Map(config.MappingParam{Name: "headers.Test", MapTo: "0"}, *req, &target)
+	err = hm.Map(config.MappingParam{Name: "headers.Test", MapTo: "0"}, req, &target)
 	assert.EqualError(t, err, "Header Test not found")
 }
 
@@ -131,15 +131,15 @@ func TestBodyMapper(t *testing.T) {
 	target := []interface{}{}
 	req := client.NewReq(context.TODO(), r, api)
 
-	err := bm.Map(api.IntegrationRequest.MappingParams[0], *req, &target)
+	err := bm.Map(api.IntegrationRequest.MappingParams[0], req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[0], "male")
 
-	err = bm.Map(api.IntegrationRequest.MappingParams[1], *req, &target)
+	err = bm.Map(api.IntegrationRequest.MappingParams[1], req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[1], "Biden")
 
-	err = bm.Map(api.IntegrationRequest.MappingParams[2], *req, &target)
+	err = bm.Map(api.IntegrationRequest.MappingParams[2], req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[2], map[string]interface{}(map[string]interface{}{"firstName": "Joe", "lastName": "Biden"}))
 }
@@ -169,9 +169,9 @@ func TestURIMapper(t *testing.T) {
 	um := uriMapper{}
 	target := []interface{}{}
 	req := client.NewReq(context.TODO(), r, api)
-	err := um.Map(api.IntegrationRequest.MappingParams[3], *req, &target)
+	err := um.Map(api.IntegrationRequest.MappingParams[3], req, &target)
 	assert.Nil(t, err)
-	err = um.Map(api.IntegrationRequest.MappingParams[2], *req, &target)
+	err = um.Map(api.IntegrationRequest.MappingParams[2], req, &target)
 	assert.Nil(t, err)
 	assert.Equal(t, target[2], "joe")
 	assert.Equal(t, target[3], "12345")

--- a/pkg/client/http/http.go
+++ b/pkg/client/http/http.go
@@ -101,11 +101,11 @@ func (dc *Client) Call(req *client.Request) (resp interface{}, err error) {
 	urlStr := req.API.IntegrationRequest.HTTPBackendConfig.Protocol + "://" + req.API.IntegrationRequest.HTTPBackendConfig.TargetURL
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 
-	request := r.IngressRequest.Clone(r.Context)
+	request := req.IngressRequest.Clone(req.Context)
 	//Map the origin paramters to backend parameters according to the API configure
-	transformedParams, err := dc.MapParams(r)
+	transformedParams, err := dc.MapParams(req)
 	if err != nil {
-		return *client.EmptyResponse, err
+		return nil, err
 	}
 	params, _ := transformedParams.(*requestParams)
 	request.Body = params.Body

--- a/pkg/client/http/http.go
+++ b/pkg/client/http/http.go
@@ -136,7 +136,7 @@ func (dc *Client) MapParams(req *client.Request) (reqData interface{}, err error
 			return nil, err
 		}
 		if mapper, ok := mappers[source]; ok {
-			if err := mapper.Map(mp[i], *req, r); err != nil {
+			if err := mapper.Map(mp[i], req, r); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/client/http/http.go
+++ b/pkg/client/http/http.go
@@ -30,11 +30,11 @@ import (
 	"github.com/apache/dubbo-go/common/constant"
 	dg "github.com/apache/dubbo-go/config"
 	"github.com/apache/dubbo-go/protocol/dubbo"
+	"github.com/pkg/errors"
 )
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
-	"github.com/pkg/errors"
 )
 
 // RestMetadata dubbo metadata, api config
@@ -122,10 +122,7 @@ func (dc *Client) MapParams(req *client.Request) (reqData interface{}, err error
 	mp := req.API.IntegrationRequest.MappingParams
 	r := newRequestParams()
 	if len(mp) == 0 {
-		r.Body, err = req.IngressRequest.GetBody()
-		if err != nil {
-			return nil, errors.New("Retrieve request body failed")
-		}
+		r.Body = req.IngressRequest.Body
 		r.Header = req.IngressRequest.Header.Clone()
 		queryValues, err := url.ParseQuery(req.IngressRequest.URL.RawQuery)
 		if err != nil {

--- a/pkg/client/http/http.go
+++ b/pkg/client/http/http.go
@@ -34,6 +34,7 @@ import (
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
+	"github.com/pkg/errors"
 )
 
 // RestMetadata dubbo metadata, api config
@@ -99,18 +100,52 @@ func (dc *Client) Call(r *client.Request) (resp client.Response, err error) {
 
 	urlStr := r.API.IntegrationRequest.HTTPBackendConfig.Protocol + "://" + r.API.IntegrationRequest.HTTPBackendConfig.TargetURL
 	httpClient := &http.Client{Timeout: 5 * time.Second}
-	request := r.IngressRequest.Clone(context.Background())
-	request.URL, _ = url.ParseRequestURI(urlStr)
-	//TODO header replace, url rewrite....
+	request := r.IngressRequest.Clone(r.Context)
+	//Map the origin paramters to backend parameters according to the API configure
+	transformedParams, err := dc.MapParams(r)
+	if err != nil {
+		return *client.EmptyResponse, err
+	}
+	params, _ := transformedParams.(*requestParams)
+	request.Body = params.Body
+	request.Header = params.Header
 
+	urlStr = strings.TrimRight(urlStr, "/") + "?" + params.Query.Encode()
+	request.URL, _ = url.ParseRequestURI(urlStr)
 	tmpRet, err := httpClient.Do(request)
 	ret := client.Response{Data: tmpRet}
 	return ret, err
 }
 
-// MappingParams param mapping to api.
-func (dc *Client) MappingParams(req *client.Request) (types []string, reqData []interface{}, err error) {
-	return nil, nil, nil
+// MapParams param mapping to api.
+func (dc *Client) MapParams(req *client.Request) (reqData interface{}, err error) {
+	mp := req.API.IntegrationRequest.MappingParams
+	r := newRequestParams()
+	if len(mp) == 0 {
+		r.Body, err = req.IngressRequest.GetBody()
+		if err != nil {
+			return nil, errors.New("Retrieve request body failed")
+		}
+		r.Header = req.IngressRequest.Header.Clone()
+		queryValues, err := url.ParseQuery(req.IngressRequest.URL.RawQuery)
+		if err != nil {
+			return nil, errors.New("Retrieve request query parameters failed")
+		}
+		r.Query = queryValues
+		return r, nil
+	}
+	for i := 0; i < len(mp); i++ {
+		source, _, err := client.ParseMapSource(mp[i].Name)
+		if err != nil {
+			return nil, err
+		}
+		if mapper, ok := mappers[source]; ok {
+			if err := mapper.Map(mp[i], *req, r); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return r, nil
 }
 
 func (dc *Client) get(key string) *dg.GenericService {

--- a/pkg/client/http/http_test.go
+++ b/pkg/client/http/http_test.go
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/mock"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+)
+
+func TestMapParams(t *testing.T) {
+	hClient := NewHTTPClient()
+	r, _ := http.NewRequest("POST", "/mock/test?team=theBoys", bytes.NewReader([]byte("{\"id\":\"12345\",\"age\":\"19\",\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\",\"nickName\":\"trump\"}}")))
+	r.Header.Set("Auth", "12345")
+	api := mock.GetMockAPI(config.MethodGet, "/mock/test")
+	req := client.NewReq(context.TODO(), r, api)
+
+	val, err := hClient.MapParams(req)
+	assert.Nil(t, err)
+	p, _ := val.(*requestParams)
+	assert.Equal(t, p.Query.Encode(), "team=theBoys")
+	assert.Equal(t, p.Header.Get("Auth"), "12345")
+	rawBody, err := ioutil.ReadAll(p.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"id\":\"12345\",\"age\":\"19\",\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\",\"nickName\":\"trump\"}}")
+
+	api.IntegrationRequest.MappingParams = []config.MappingParam{
+		{
+			Name:  "queryStrings.team",
+			MapTo: "queryStrings.team",
+		},
+		{
+			Name:  "requestBody.id",
+			MapTo: "headers.Id",
+		},
+		{
+			Name:  "headers.Auth",
+			MapTo: "queryStrings.auth",
+		},
+		{
+			Name:  "requestBody.age",
+			MapTo: "requestBody.age",
+		},
+		{
+			Name:  "requestBody.testStruct",
+			MapTo: "requestBody.testStruct",
+		},
+		{
+			Name:  "requestBody.testStruct.nickName",
+			MapTo: "requestBody.nickName",
+		},
+	}
+	api.IntegrationRequest.HTTPBackendConfig.Protocol = "https"
+	api.IntegrationRequest.HTTPBackendConfig.TargetURL = "localhost"
+	req = client.NewReq(context.TODO(), r, api)
+	val, err = hClient.MapParams(req)
+	assert.Nil(t, err)
+	p, _ = val.(*requestParams)
+	assert.Equal(t, p.Header.Get("Id"), "12345")
+	assert.Equal(t, p.Query.Get("auth"), "12345")
+	assert.Equal(t, p.Query.Get("team"), "theBoys")
+	rawBody, err = ioutil.ReadAll(p.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"age\":\"19\",\"nickName\":\"trump\",\"testStruct\":{\"name\":\"mock\",\"nickName\":\"trump\",\"test\":\"happy\"}}")
+
+	hClient.Call(req)
+}

--- a/pkg/client/http/http_test.go
+++ b/pkg/client/http/http_test.go
@@ -79,6 +79,8 @@ func TestMapParams(t *testing.T) {
 	}
 	api.IntegrationRequest.HTTPBackendConfig.Protocol = "https"
 	api.IntegrationRequest.HTTPBackendConfig.TargetURL = "localhost"
+	r, _ = http.NewRequest("POST", "/mock/test?team=theBoys", bytes.NewReader([]byte("{\"id\":\"12345\",\"age\":\"19\",\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\",\"nickName\":\"trump\"}}")))
+	r.Header.Set("Auth", "12345")
 	req = client.NewReq(context.TODO(), r, api)
 	val, err = hClient.MapParams(req)
 	assert.Nil(t, err)

--- a/pkg/client/http/mapper.go
+++ b/pkg/client/http/mapper.go
@@ -60,6 +60,7 @@ func newRequestParams() *requestParams {
 
 type queryStringsMapper struct{}
 
+// nolint
 func (qs queryStringsMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
 	rv, err := validateTarget(rawTarget)
 	if err != nil {
@@ -87,6 +88,7 @@ func (qs queryStringsMapper) Map(mp config.MappingParam, c client.Request, rawTa
 
 type headerMapper struct{}
 
+// nolint
 func (hm headerMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
 	target, err := validateTarget(rawTarget)
 	if err != nil {
@@ -111,6 +113,7 @@ func (hm headerMapper) Map(mp config.MappingParam, c client.Request, rawTarget i
 
 type bodyMapper struct{}
 
+// nolint
 func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
 	// TO-DO: add support for content-type other than application/json
 	target, err := validateTarget(rawTarget)

--- a/pkg/client/http/mapper.go
+++ b/pkg/client/http/mapper.go
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+)
+
+var mappers = map[string]client.ParamMapper{
+	constant.QueryStrings: queryStringsMapper{},
+	constant.Headers:      headerMapper{},
+	constant.RequestBody:  bodyMapper{},
+}
+
+type requestParams struct {
+	Header http.Header
+	Query  url.Values
+	Body   io.ReadCloser
+}
+
+func newRequestParams() *requestParams {
+	return &requestParams{
+		Header: http.Header{},
+		Query:  url.Values{},
+		Body:   ioutil.NopCloser(bytes.NewReader([]byte(""))),
+	}
+}
+
+type queryStringsMapper struct{}
+
+func (qs queryStringsMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+	rv, err := validateTarget(rawTarget)
+	if err != nil {
+		return err
+	}
+	_, fromKey, err := client.ParseMapSource(mp.Name)
+	if err != nil {
+		return err
+	}
+	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	if err != nil {
+		return err
+	}
+	queryValues, err := url.ParseQuery(c.IngressRequest.URL.RawQuery)
+	if err != nil {
+		return errors.Wrap(err, "Error happened when parsing the query paramters")
+	}
+	rawValue := queryValues.Get(fromKey[0])
+	if len(rawValue) == 0 {
+		return errors.Errorf("%s in query parameters not found", fromKey[0])
+	}
+	setTarget(rv, to, toKey[0], rawValue)
+	return nil
+}
+
+type headerMapper struct{}
+
+func (hm headerMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+	target, err := validateTarget(rawTarget)
+	if err != nil {
+		return err
+	}
+	_, fromKey, err := client.ParseMapSource(mp.Name)
+	if err != nil {
+		return err
+	}
+	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	if err != nil {
+		return err
+	}
+
+	rawHeader := c.IngressRequest.Header.Get(fromKey[0])
+	if len(rawHeader) == 0 {
+		return errors.Errorf("Header %s not found", fromKey[0])
+	}
+	setTarget(target, to, toKey[0], rawHeader)
+	return nil
+}
+
+type bodyMapper struct{}
+
+func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+	// TO-DO: add support for content-type other than application/json
+	target, err := validateTarget(rawTarget)
+	if err != nil {
+		return err
+	}
+	_, fromKey, err := client.ParseMapSource(mp.Name)
+	if err != nil {
+		return err
+	}
+	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	if err != nil {
+		return err
+	}
+
+	body, err := c.IngressRequest.GetBody()
+	if err != nil {
+		return err
+	}
+	rawBody, err := ioutil.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	mapBody := map[string]interface{}{}
+	json.Unmarshal(rawBody, &mapBody)
+	val, err := client.GetMapValue(mapBody, fromKey)
+
+	setTarget(target, to, strings.Join(toKey, constant.Dot), val)
+	return nil
+}
+
+func validateTarget(target interface{}) (*requestParams, error) {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return nil, errors.New("Target params must be a non-nil pointer")
+	}
+	val, ok := target.(*requestParams)
+	if !ok {
+		return nil, errors.New("Target params must be a requestParams pointer")
+	}
+	return val, nil
+}
+
+func setTarget(target *requestParams, to string, key string, val interface{}) error {
+	valType := reflect.TypeOf(val)
+	if (to == constant.Headers || to == constant.QueryStrings) && valType.Kind() != reflect.String {
+		return errors.Errorf("%s only accepts string", to)
+	}
+	switch to {
+	case constant.Headers:
+		target.Header.Set(key, val.(string))
+	case constant.QueryStrings:
+		target.Query.Set(key, val.(string))
+	case constant.RequestBody:
+		rawBody, err := ioutil.ReadAll(target.Body)
+		if err != nil {
+			return errors.New("Raw body parse failed")
+		}
+		mapBody := map[string]interface{}{}
+		json.Unmarshal(rawBody, &mapBody)
+
+		setMapWithPath(mapBody, key, val)
+		rawBody, err = json.Marshal(mapBody)
+		if err != nil {
+			return errors.New("Stringify map to body failed")
+		}
+		target.Body = ioutil.NopCloser(bytes.NewReader(rawBody))
+	default:
+		return errors.Errorf("Mapping target to %s does not support", to)
+	}
+	return nil
+}
+
+// setMapWithPath set the value to the target map. If the origin targetMap has
+// {"abc": "cde": {"f":1, "g":2}} and the path is abc, value is "123", then the
+// targetMap will be updated to {"abc", "123"}
+func setMapWithPath(targetMap map[string]interface{}, path string, val interface{}) map[string]interface{} {
+	keys := strings.Split(path, constant.Dot)
+
+	_, ok := targetMap[keys[0]]
+	if len(keys) == 1 {
+		targetMap[keys[0]] = val
+		return targetMap
+	}
+	if !ok && len(keys) != 1 {
+		targetMap[keys[0]] = make(map[string]interface{})
+		targetMap[keys[0]] = setMapWithPath(targetMap[keys[0]].(map[string]interface{}), strings.Join(keys[1:len(keys)], constant.Dot), val)
+	}
+	return targetMap
+}

--- a/pkg/client/http/mapper.go
+++ b/pkg/client/http/mapper.go
@@ -61,7 +61,7 @@ func newRequestParams() *requestParams {
 type queryStringsMapper struct{}
 
 // nolint
-func (qs queryStringsMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+func (qs queryStringsMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}) error {
 	rv, err := validateTarget(rawTarget)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (qs queryStringsMapper) Map(mp config.MappingParam, c client.Request, rawTa
 type headerMapper struct{}
 
 // nolint
-func (hm headerMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+func (hm headerMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}) error {
 	target, err := validateTarget(rawTarget)
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (hm headerMapper) Map(mp config.MappingParam, c client.Request, rawTarget i
 type bodyMapper struct{}
 
 // nolint
-func (bm bodyMapper) Map(mp config.MappingParam, c client.Request, rawTarget interface{}) error {
+func (bm bodyMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}) error {
 	// TO-DO: add support for content-type other than application/json
 	target, err := validateTarget(rawTarget)
 	if err != nil {

--- a/pkg/client/http/mapper_test.go
+++ b/pkg/client/http/mapper_test.go
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/client"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/mock"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
+)
+
+func TestQueryMapper(t *testing.T) {
+	qs := queryStringsMapper{}
+	r, _ := http.NewRequest("GET", "/mock/test?id=12345&age=19&name=joe&nickName=trump", bytes.NewReader([]byte("")))
+	api := mock.GetMockAPI(config.MethodGet, "/mock/test")
+	api.IntegrationRequest.MappingParams = []config.MappingParam{
+		{
+			Name:  "queryStrings.id",
+			MapTo: "headers.Id",
+		},
+		{
+			Name:  "queryStrings.name",
+			MapTo: "queryStrings.name",
+		},
+		{
+			Name:  "queryStrings.age",
+			MapTo: "requestBody.age",
+		},
+		{
+			Name:  "queryStrings.nickName",
+			MapTo: "requestBody.nickName",
+		},
+	}
+	req := client.NewReq(context.TODO(), r, api)
+
+	target := newRequestParams()
+	err := qs.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Header.Get("Id"), "12345")
+
+	err = qs.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Query.Get("name"), "joe")
+
+	err = qs.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	assert.Nil(t, err)
+	err = qs.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	assert.Nil(t, err)
+	rawBody, _ := ioutil.ReadAll(target.Body)
+	assert.Equal(t, string(rawBody), "{\"age\":\"19\",\"nickName\":\"trump\"}")
+
+	err = qs.Map(config.MappingParam{Name: "queryStrings.doesNotExistField", MapTo: "queryStrings.whatever"}, *req, target)
+	assert.EqualError(t, err, "doesNotExistField in query parameters not found")
+}
+
+func TestHeaderMapper(t *testing.T) {
+	hm := headerMapper{}
+	r, _ := http.NewRequest("GET", "/mock/test?id=12345&age=19&name=joe&nickName=trump", bytes.NewReader([]byte("")))
+	r.Header.Set("Auth", "xxxx12345xxx")
+	r.Header.Set("Token", "ttttt12345ttt")
+	r.Header.Set("Origin-Passcode", "whoseyourdaddy")
+	r.Header.Set("Pokemon-Name", "Pika")
+	api := mock.GetMockAPI(config.MethodGet, "/mock/test")
+	api.IntegrationRequest.MappingParams = []config.MappingParam{
+		{
+			Name:  "headers.Auth",
+			MapTo: "headers.Auth",
+		},
+		{
+			Name:  "headers.Token",
+			MapTo: "headers.Token",
+		},
+		{
+			Name:  "headers.Origin-Passcode",
+			MapTo: "queryStrings.originPasscode",
+		},
+		{
+			Name:  "headers.Pokemon-Name",
+			MapTo: "requestBody.pokeMonName",
+		},
+	}
+	req := client.NewReq(context.TODO(), r, api)
+
+	target := newRequestParams()
+	err := hm.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Header.Get("Auth"), "xxxx12345xxx")
+	err = hm.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Header.Get("Token"), "ttttt12345ttt")
+
+	err = hm.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Query.Get("originPasscode"), "whoseyourdaddy")
+
+	err = hm.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	assert.Nil(t, err)
+	rawBody, err := ioutil.ReadAll(target.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"pokeMonName\":\"Pika\"}")
+
+	err = hm.Map(config.MappingParam{Name: "headers.doesNotExistField", MapTo: "headers.whatever"}, *req, target)
+	assert.EqualError(t, err, "Header doesNotExistField not found")
+}
+
+func TestBodyMapper(t *testing.T) {
+	bm := bodyMapper{}
+	r, _ := http.NewRequest("POST", "/mock/test", bytes.NewReader([]byte("{\"id\":\"12345\",\"age\":\"19\",\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\",\"nickName\":\"trump\"}}")))
+	api := mock.GetMockAPI(config.MethodGet, "/mock/test")
+	api.IntegrationRequest.MappingParams = []config.MappingParam{
+		{
+			Name:  "requestBody.id",
+			MapTo: "headers.Id",
+		},
+		{
+			Name:  "requestBody.age",
+			MapTo: "requestBody.age",
+		},
+		{
+			Name:  "requestBody.testStruct",
+			MapTo: "requestBody.testStruct",
+		},
+		{
+			Name:  "requestBody.testStruct.nickName",
+			MapTo: "requestBody.nickName",
+		},
+	}
+	req := client.NewReq(context.TODO(), r, api)
+
+	target := newRequestParams()
+	err := bm.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	assert.Nil(t, err)
+	assert.Equal(t, target.Header.Get("Id"), "12345")
+
+	target = newRequestParams()
+	err = bm.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	assert.Nil(t, err)
+
+	err = bm.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	assert.Nil(t, err)
+
+	err = bm.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	assert.Nil(t, err)
+	rawBody, err := ioutil.ReadAll(target.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"age\":\"19\",\"nickName\":\"trump\",\"testStruct\":{\"name\":\"mock\",\"nickName\":\"trump\",\"test\":\"happy\"}}")
+}
+
+func TestSetTarget(t *testing.T) {
+	emptyRequestParams := newRequestParams()
+	err := setTarget(emptyRequestParams, constant.Headers, "Auth", "1234565")
+	assert.Nil(t, err)
+	assert.Equal(t, emptyRequestParams.Header.Get("Auth"), "1234565")
+	err = setTarget(emptyRequestParams, constant.Headers, "Auth", 1234565)
+	assert.EqualError(t, err, "headers only accepts string")
+
+	err = setTarget(emptyRequestParams, constant.QueryStrings, "id", "123")
+	assert.Nil(t, err)
+	assert.Equal(t, emptyRequestParams.Query.Get("id"), "123")
+	err = setTarget(emptyRequestParams, constant.QueryStrings, "id", 123)
+	assert.EqualError(t, err, "queryStrings only accepts string")
+
+	err = setTarget(emptyRequestParams, constant.RequestBody, "testStruct", map[string]interface{}{"test": "happy", "name": "mock"})
+	assert.Nil(t, err)
+	rawBody, err := ioutil.ReadAll(emptyRequestParams.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\"}}")
+
+	err = setTarget(emptyRequestParams, constant.RequestBody, "testStruct.secondLayer", map[string]interface{}{"test": "happy", "name": "mock"})
+	assert.Nil(t, err)
+	rawBody, err = ioutil.ReadAll(emptyRequestParams.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"testStruct\":{\"secondLayer\":{\"name\":\"mock\",\"test\":\"happy\"}}}")
+
+	err = setTarget(emptyRequestParams, constant.RequestBody, "testStruct.secondLayer.thirdLayer", map[string]interface{}{"test": "happy", "name": "mock"})
+	assert.Nil(t, err)
+	rawBody, err = ioutil.ReadAll(emptyRequestParams.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"testStruct\":{\"secondLayer\":{\"thirdLayer\":{\"name\":\"mock\",\"test\":\"happy\"}}}}")
+
+	nonEmptyRequestParams := newRequestParams()
+	nonEmptyRequestParams.Body = ioutil.NopCloser(bytes.NewReader([]byte("{\"testStruct\":\"abcde\"}")))
+	err = setTarget(nonEmptyRequestParams, constant.RequestBody, "testStruct", map[string]interface{}{"test": "happy", "name": "mock"})
+	assert.Nil(t, err)
+	rawBody, err = ioutil.ReadAll(nonEmptyRequestParams.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\"}}")
+
+	nonEmptyRequestParams = newRequestParams()
+	nonEmptyRequestParams.Body = ioutil.NopCloser(bytes.NewReader([]byte("{\"otherStructure\":\"abcde\"}")))
+	err = setTarget(nonEmptyRequestParams, constant.RequestBody, "testStruct", map[string]interface{}{"test": "happy", "name": "mock"})
+	assert.Nil(t, err)
+	rawBody, err = ioutil.ReadAll(nonEmptyRequestParams.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, string(rawBody), "{\"otherStructure\":\"abcde\",\"testStruct\":{\"name\":\"mock\",\"test\":\"happy\"}}")
+}

--- a/pkg/client/http/mapper_test.go
+++ b/pkg/client/http/mapper_test.go
@@ -61,22 +61,22 @@ func TestQueryMapper(t *testing.T) {
 	req := client.NewReq(context.TODO(), r, api)
 
 	target := newRequestParams()
-	err := qs.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	err := qs.Map(api.IntegrationRequest.MappingParams[0], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Header.Get("Id"), "12345")
 
-	err = qs.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	err = qs.Map(api.IntegrationRequest.MappingParams[1], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Query.Get("name"), "joe")
 
-	err = qs.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	err = qs.Map(api.IntegrationRequest.MappingParams[2], req, target)
 	assert.Nil(t, err)
-	err = qs.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	err = qs.Map(api.IntegrationRequest.MappingParams[3], req, target)
 	assert.Nil(t, err)
 	rawBody, _ := ioutil.ReadAll(target.Body)
 	assert.Equal(t, string(rawBody), "{\"age\":\"19\",\"nickName\":\"trump\"}")
 
-	err = qs.Map(config.MappingParam{Name: "queryStrings.doesNotExistField", MapTo: "queryStrings.whatever"}, *req, target)
+	err = qs.Map(config.MappingParam{Name: "queryStrings.doesNotExistField", MapTo: "queryStrings.whatever"}, req, target)
 	assert.EqualError(t, err, "doesNotExistField in query parameters not found")
 }
 
@@ -109,24 +109,24 @@ func TestHeaderMapper(t *testing.T) {
 	req := client.NewReq(context.TODO(), r, api)
 
 	target := newRequestParams()
-	err := hm.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	err := hm.Map(api.IntegrationRequest.MappingParams[0], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Header.Get("Auth"), "xxxx12345xxx")
-	err = hm.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	err = hm.Map(api.IntegrationRequest.MappingParams[1], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Header.Get("Token"), "ttttt12345ttt")
 
-	err = hm.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	err = hm.Map(api.IntegrationRequest.MappingParams[2], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Query.Get("originPasscode"), "whoseyourdaddy")
 
-	err = hm.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	err = hm.Map(api.IntegrationRequest.MappingParams[3], req, target)
 	assert.Nil(t, err)
 	rawBody, err := ioutil.ReadAll(target.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, string(rawBody), "{\"pokeMonName\":\"Pika\"}")
 
-	err = hm.Map(config.MappingParam{Name: "headers.doesNotExistField", MapTo: "headers.whatever"}, *req, target)
+	err = hm.Map(config.MappingParam{Name: "headers.doesNotExistField", MapTo: "headers.whatever"}, req, target)
 	assert.EqualError(t, err, "Header doesNotExistField not found")
 }
 
@@ -155,18 +155,18 @@ func TestBodyMapper(t *testing.T) {
 	req := client.NewReq(context.TODO(), r, api)
 
 	target := newRequestParams()
-	err := bm.Map(api.IntegrationRequest.MappingParams[0], *req, target)
+	err := bm.Map(api.IntegrationRequest.MappingParams[0], req, target)
 	assert.Nil(t, err)
 	assert.Equal(t, target.Header.Get("Id"), "12345")
 
 	target = newRequestParams()
-	err = bm.Map(api.IntegrationRequest.MappingParams[1], *req, target)
+	err = bm.Map(api.IntegrationRequest.MappingParams[1], req, target)
 	assert.Nil(t, err)
 
-	err = bm.Map(api.IntegrationRequest.MappingParams[2], *req, target)
+	err = bm.Map(api.IntegrationRequest.MappingParams[2], req, target)
 	assert.Nil(t, err)
 
-	err = bm.Map(api.IntegrationRequest.MappingParams[3], *req, target)
+	err = bm.Map(api.IntegrationRequest.MappingParams[3], req, target)
 	assert.Nil(t, err)
 	rawBody, err := ioutil.ReadAll(target.Body)
 	assert.Nil(t, err)

--- a/pkg/client/mapper.go
+++ b/pkg/client/mapper.go
@@ -33,6 +33,7 @@ import (
 
 // ParamMapper defines the interface about how to map the params in the inbound request.
 type ParamMapper interface {
+	// Map implements how the request parameters map to the target parameters described by config.MappingParam
 	Map(config.MappingParam, Request, interface{}) error
 }
 

--- a/pkg/client/mapper.go
+++ b/pkg/client/mapper.go
@@ -34,7 +34,7 @@ import (
 // ParamMapper defines the interface about how to map the params in the inbound request.
 type ParamMapper interface {
 	// Map implements how the request parameters map to the target parameters described by config.MappingParam
-	Map(config.MappingParam, Request, interface{}) error
+	Map(config.MappingParam, *Request, interface{}) error
 }
 
 // ParseMapSource parses the source parameter config in the mappingParams

--- a/pkg/client/mapper_test.go
+++ b/pkg/client/mapper_test.go
@@ -68,4 +68,11 @@ func TestGetMapValue(t *testing.T) {
 	val, err = GetMapValue(testMap, []string{"structure", "name"})
 	assert.Nil(t, err)
 	assert.Equal(t, val, "joe")
+	val, err = GetMapValue(map[string]interface{}{}, []string{"structure"})
+	assert.Nil(t, val)
+	assert.EqualError(t, err, "structure does not exist in request body")
+
+	val, err = GetMapValue(map[string]interface{}{"structure": "test"}, []string{"structure", "name"})
+	assert.Nil(t, val)
+	assert.EqualError(t, err, "structure is not a map structure. It contains test")
 }

--- a/pkg/client/mapper_test.go
+++ b/pkg/client/mapper_test.go
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMapSource(t *testing.T) {
+	from, key, err := ParseMapSource("queryStrings.id")
+	assert.Nil(t, err)
+	assert.Equal(t, from, "queryStrings")
+	assert.Equal(t, key[0], "id")
+
+	from, key, err = ParseMapSource("headers.id")
+	assert.Nil(t, err)
+	assert.Equal(t, from, "headers")
+	assert.Equal(t, key[0], "id")
+
+	from, key, err = ParseMapSource("requestBody.user.id")
+	assert.Nil(t, err)
+	assert.Equal(t, from, "requestBody")
+	assert.Equal(t, key[0], "user")
+	assert.Equal(t, key[1], "id")
+
+	from, key, err = ParseMapSource("what.user.id")
+	assert.EqualError(t, err, "Parameter mapping config incorrect. Please fix it")
+	from, key, err = ParseMapSource("requestBody.*userid")
+	assert.EqualError(t, err, "Parameter mapping config incorrect. Please fix it")
+}
+
+func TestGetMapValue(t *testing.T) {
+	testMap := map[string]interface{}{
+		"Test": "test",
+		"structure": map[string]interface{}{
+			"name": "joe",
+			"age":  77,
+		},
+	}
+	val, err := GetMapValue(testMap, []string{"Test"})
+	assert.Nil(t, err)
+	assert.Equal(t, val, "test")
+	val, err = GetMapValue(testMap, []string{"test"})
+	assert.Nil(t, val)
+	assert.EqualError(t, err, "test does not exist in request body")
+	val, err = GetMapValue(testMap, []string{"structure"})
+	assert.Nil(t, err)
+	assert.Equal(t, val, testMap["structure"])
+	val, err = GetMapValue(testMap, []string{"structure", "name"})
+	assert.Nil(t, err)
+	assert.Equal(t, val, "joe")
+}

--- a/pkg/common/constant/url.go
+++ b/pkg/common/constant/url.go
@@ -36,6 +36,9 @@ const (
 	QueryStrings = "queryStrings"
 	// Headers name of api config mapping from/to
 	Headers = "headers"
+	// RequestURI name of api config mapping from/to, retrieve parameters from uri
+	// for instance, https://test.com/:id uri.id will retrieve the :id parameter
+	RequestURI = "uri"
 	// Dot defines the . which will be used to present the path to specific field in the body
 	Dot = "."
 )

--- a/pkg/common/constant/url.go
+++ b/pkg/common/constant/url.go
@@ -28,3 +28,14 @@ const (
 	// RetriesKey retry times
 	RetriesKey = "retries"
 )
+
+const (
+	// RequestBody name of api config mapping from/to
+	RequestBody = "requestBody"
+	// QueryStrings name of api config mapping from/to
+	QueryStrings = "queryStrings"
+	// Headers name of api config mapping from/to
+	Headers = "headers"
+	// Dot defines the . which will be used to present the path to specific field in the body
+	Dot = "."
+)

--- a/pkg/router/api.go
+++ b/pkg/router/api.go
@@ -19,11 +19,11 @@ package router
 
 import (
 	"net/url"
+	"strings"
 )
 
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
-	"strings"
 )
 
 // API describes the minimum configuration of an RESTful api configure in gateway

--- a/pkg/router/api_test.go
+++ b/pkg/router/api_test.go
@@ -18,10 +18,16 @@
 package router
 
 import (
-	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
 )
 
 func TestGetURIParams(t *testing.T) {

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -18,6 +18,7 @@
 package router
 
 import (
+	"net/url"
 	"strings"
 	"sync"
 )
@@ -30,7 +31,6 @@ import (
 import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
-	"net/url"
 )
 
 // Node defines the single method of the router configured API

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -167,16 +167,21 @@ func TestSearchWildcard(t *testing.T) {
 }
 
 func TestWildcardMatch(t *testing.T) {
-	assert.True(t, wildcardMatch("/vought/:id", "/vought/12345"))
-	assert.True(t, wildcardMatch("/vought/:id", "/vought/125abc"))
-	assert.False(t, wildcardMatch("/vought/:id", "/vought/1234abcd/status"))
-	assert.True(t, wildcardMatch("/voughT/:id/:action", "/Vought/1234abcd/attack"))
-}
-
-func TestPutResource(t *testing.T) {
-	rt := NewRoute()
-	err := rt.PutResource()
-	assert.Nil(t, err)
+	vals := wildcardMatch("/vought/:id", "/vought/12345")
+	assert.NotNil(t, vals)
+	assert.Equal(t, vals.Get("id"), "12345")
+	vals = wildcardMatch("/vought/:id", "/vought/125abc")
+	assert.NotNil(t, vals)
+	assert.Equal(t, vals.Get("id"), "125abc")
+	vals = wildcardMatch("/vought/:id", "/vought/1234abcd/status")
+	assert.Nil(t, vals)
+	vals = wildcardMatch("/voughT/:id/:action", "/Vought/1234abcd/attack")
+	assert.NotNil(t, vals)
+	assert.Equal(t, vals.Get("id"), "1234abcd")
+	assert.Equal(t, vals.Get("action"), "attack")
+	vals = wildcardMatch("/voughT/:id/status", "/Vought/1234abcd/status")
+	assert.NotNil(t, vals)
+	assert.Equal(t, vals.Get("id"), "1234abcd")
 }
 
 func TestGetFilters(t *testing.T) {

--- a/sample/dubbogo/proxy/api_config.yaml
+++ b/sample/dubbogo/proxy/api_config.yaml
@@ -9,7 +9,7 @@ resources:
     methods:
       - httpVerb: GET
         onAir: true
-        timeout: 100ms
+        timeout: 1000ms
         inboundRequest:
           requestType: http
           queryStrings:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

- adding parameters mapping for http-2-http gateway
- adding retrieving URI parameters from request and map to dubbo parameters.
- bug fix of using request.GetBody on server side

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #54  #56 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```