### PR TITLE
add uri support for http

### DIFF
--- a/pkg/client/dubbo/mapper_test.go
+++ b/pkg/client/dubbo/mapper_test.go
@@ -145,7 +145,7 @@ func TestBodyMapper(t *testing.T) {
 }
 
 func TestURIMapper(t *testing.T) {
-	r, _ := http.NewRequest("POST", "/mock/12345/joe&age=19", bytes.NewReader([]byte(`{"sex": "male", "name":{"firstName": "Joe", "lastName": "Biden"}}`)))
+	r, _ := http.NewRequest("POST", "/mock/12345/joe?age=19", bytes.NewReader([]byte(`{"sex": "male", "name":{"firstName": "Joe", "lastName": "Biden"}}`)))
 	r.Header.Set("Auth", "1234567")
 	api := mock.GetMockAPI(config.MethodGet, "/mock/:id/:name")
 	api.IntegrationRequest.MappingParams = []config.MappingParam{

--- a/pkg/client/http/mapper.go
+++ b/pkg/client/http/mapper.go
@@ -42,19 +42,22 @@ var mappers = map[string]client.ParamMapper{
 	constant.QueryStrings: queryStringsMapper{},
 	constant.Headers:      headerMapper{},
 	constant.RequestBody:  bodyMapper{},
+	constant.RequestURI:   uriMapper{},
 }
 
 type requestParams struct {
-	Header http.Header
-	Query  url.Values
-	Body   io.ReadCloser
+	Header    http.Header
+	Query     url.Values
+	Body      io.ReadCloser
+	URIParams url.Values
 }
 
 func newRequestParams() *requestParams {
 	return &requestParams{
-		Header: http.Header{},
-		Query:  url.Values{},
-		Body:   ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Header:    http.Header{},
+		Query:     url.Values{},
+		Body:      ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		URIParams: url.Values{},
 	}
 }
 
@@ -62,15 +65,7 @@ type queryStringsMapper struct{}
 
 // nolint
 func (qs queryStringsMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}, option client.IOption) error {
-	rv, err := validateTarget(rawTarget)
-	if err != nil {
-		return err
-	}
-	_, fromKey, err := client.ParseMapSource(mp.Name)
-	if err != nil {
-		return err
-	}
-	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	target, fromKey, to, toKey, err := mapPrepare(mp, rawTarget)
 	if err != nil {
 		return err
 	}
@@ -82,7 +77,7 @@ func (qs queryStringsMapper) Map(mp config.MappingParam, c *client.Request, rawT
 	if len(rawValue) == 0 {
 		return errors.Errorf("%s in query parameters not found", fromKey[0])
 	}
-	setTarget(rv, to, toKey[0], rawValue)
+	setTarget(target, to, toKey[0], rawValue)
 	return nil
 }
 
@@ -90,15 +85,7 @@ type headerMapper struct{}
 
 // nolint
 func (hm headerMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}, option client.IOption) error {
-	target, err := validateTarget(rawTarget)
-	if err != nil {
-		return err
-	}
-	_, fromKey, err := client.ParseMapSource(mp.Name)
-	if err != nil {
-		return err
-	}
-	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	target, fromKey, to, toKey, err := mapPrepare(mp, rawTarget)
 	if err != nil {
 		return err
 	}
@@ -116,15 +103,7 @@ type bodyMapper struct{}
 // nolint
 func (bm bodyMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}, option client.IOption) error {
 	// TO-DO: add support for content-type other than application/json
-	target, err := validateTarget(rawTarget)
-	if err != nil {
-		return err
-	}
-	_, fromKey, err := client.ParseMapSource(mp.Name)
-	if err != nil {
-		return err
-	}
-	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	target, fromKey, to, toKey, err := mapPrepare(mp, rawTarget)
 	if err != nil {
 		return err
 	}
@@ -143,6 +122,25 @@ func (bm bodyMapper) Map(mp config.MappingParam, c *client.Request, rawTarget in
 		return errors.Wrapf(err, "Error when get body value from key %s", fromKey)
 	}
 	setTarget(target, to, strings.Join(toKey, constant.Dot), val)
+	return nil
+}
+
+type uriMapper struct{}
+
+// nolint
+func (um uriMapper) Map(mp config.MappingParam, c *client.Request, rawTarget interface{}, option client.IOption) error {
+	target, fromKey, to, toKey, err := mapPrepare(mp, rawTarget)
+	if err != nil {
+		return err
+	}
+	if to == constant.RequestURI {
+
+	}
+	uriValues := c.API.GetURIParams(*c.IngressRequest.URL)
+	if uriValues == nil {
+		return errors.New("No URI parameters found")
+	}
+	setTarget(target, to, strings.Join(toKey, constant.Dot), uriValues.Get(fromKey[0]))
 	return nil
 }
 
@@ -166,6 +164,8 @@ func setTarget(target *requestParams, to string, key string, val interface{}) er
 	switch to {
 	case constant.Headers:
 		target.Header.Set(key, val.(string))
+	case constant.RequestURI:
+		target.URIParams.Set(key, val.(string))
 	case constant.QueryStrings:
 		target.Query.Set(key, val.(string))
 	case constant.RequestBody:
@@ -206,4 +206,20 @@ func setMapWithPath(targetMap map[string]interface{}, path string, val interface
 		targetMap[keys[0]] = setMapWithPath(targetMap[keys[0]].(map[string]interface{}), strings.Join(keys[1:len(keys)], constant.Dot), val)
 	}
 	return targetMap
+}
+
+func mapPrepare(mp config.MappingParam, rawTarget interface{}) (*requestParams, []string, string, []string, error) {
+	target, err := validateTarget(rawTarget)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+	_, fromKey, err := client.ParseMapSource(mp.Name)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+	return target, fromKey, to, toKey, nil
 }

--- a/pkg/client/http/mapper.go
+++ b/pkg/client/http/mapper.go
@@ -208,16 +208,19 @@ func setMapWithPath(targetMap map[string]interface{}, path string, val interface
 	return targetMap
 }
 
-func mapPrepare(mp config.MappingParam, rawTarget interface{}) (*requestParams, []string, string, []string, error) {
-	target, err := validateTarget(rawTarget)
+func mapPrepare(mp config.MappingParam, rawTarget interface{}) (target *requestParams, fromKey []string, to string, toKey []string, err error) {
+	// ensure the target is a pointer and type is requestParams
+	target, err = validateTarget(rawTarget)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
-	_, fromKey, err := client.ParseMapSource(mp.Name)
+	// retrieve the mapping values' origin param name
+	_, fromKey, err = client.ParseMapSource(mp.Name)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
-	to, toKey, err := client.ParseMapSource(mp.MapTo)
+	// retrieve the mapping values' target param name and param types(header/uri/query/request body)
+	to, toKey, err = client.ParseMapSource(mp.MapTo)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -29,8 +29,7 @@ import (
 
 // Request request for endpoint
 type Request struct {
-	Context context.Context
-
+	Context        context.Context
 	IngressRequest *http.Request
 	API            router.API
 }

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -215,7 +215,7 @@ type HTTPBackendConfig struct {
 	// path to replace.
 	Path string `yaml:"path" json:"path,omitempty"`
 	// http protocol, http or https.
-	Scheme string `yaml:"scheme" json:"scheme,omitempty"`
+	Schema string `yaml:"schema" json:"scheme,omitempty"`
 }
 
 // Definition defines the complex json request body

--- a/pkg/router/api.go
+++ b/pkg/router/api.go
@@ -23,6 +23,7 @@ import (
 )
 
 import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/common/constant"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/config"
 )
 
@@ -34,6 +35,14 @@ type API struct {
 
 // GetURIParams returns the values retrieved from the rawURL
 func (api *API) GetURIParams(rawURL url.URL) url.Values {
-	sourceURL := strings.Split(rawURL.Path, "&")[0]
-	return wildcardMatch(api.URLPattern, sourceURL)
+	return wildcardMatch(api.URLPattern, rawURL.Path)
+}
+
+// IsWildCardBackendPath checks whether the configured path of
+// the upstream restful service contains parameters
+func (api *API) IsWildCardBackendPath() bool {
+	if len(api.IntegrationRequest.Path) == 0 {
+		return false
+	}
+	return strings.Contains(api.IntegrationRequest.Path, constant.PathParamIdentifier)
 }

--- a/pkg/router/api_test.go
+++ b/pkg/router/api_test.go
@@ -45,6 +45,11 @@ func TestGetURIParams(t *testing.T) {
 	assert.Equal(t, values.Get("id"), "12345")
 	assert.Equal(t, values.Get("name"), "Joe")
 
+	u, _ = url.Parse("https://test.com/Mock/12345/Joe&jack")
+	values = api.GetURIParams(*u)
+	assert.Equal(t, values.Get("id"), "12345")
+	assert.Equal(t, values.Get("name"), "Joe&jack")
+
 	u, _ = url.Parse("https://test.com/mock/12345")
 	values = api.GetURIParams(*u)
 	assert.Nil(t, values)
@@ -53,4 +58,24 @@ func TestGetURIParams(t *testing.T) {
 	u, _ = url.Parse("https://test.com/mock/12345/Joe?status=up")
 	values = api.GetURIParams(*u)
 	assert.Nil(t, values)
+
+	api.URLPattern = "/mock/test"
+	u, _ = url.Parse("https://test.com/mock/12345/Joe&Jack")
+	values = api.GetURIParams(*u)
+	assert.Nil(t, values)
+}
+
+func TestIsWildCardBackendPath(t *testing.T) {
+	mockAPI := API{
+		URLPattern: "/mock/:id/:name",
+		Method:     getMockMethod(config.MethodGet),
+	}
+	mockAPI.IntegrationRequest.Path = "/mock/:id"
+	assert.True(t, mockAPI.IsWildCardBackendPath())
+
+	mockAPI.IntegrationRequest.Path = "/mock/test"
+	assert.False(t, mockAPI.IsWildCardBackendPath())
+
+	mockAPI.IntegrationRequest.Path = ""
+	assert.False(t, mockAPI.IsWildCardBackendPath())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Add support to mapping URI to upstream service.
1. If the inbound request and the backend http service contains wildcard params, it can automatically map it.
2. Config the mapping param uri.xx to map to any params you need.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #56

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```