### PR TITLE
header filter

### DIFF
--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -76,13 +76,14 @@ type APIConfig struct {
 
 // Resource defines the API path
 type Resource struct {
-	Type        string        `json:"type" yaml:"type"` // Restful, Dubbo
-	Path        string        `json:"path" yaml:"path"`
-	Timeout     time.Duration `json:"timeout" yaml:"timeout"`
-	Description string        `json:"description" yaml:"description"`
-	Filters     []string      `json:"filters" yaml:"filters"`
-	Methods     []Method      `json:"methods" yaml:"methods"`
-	Resources   []Resource    `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Type        string            `json:"type" yaml:"type"` // Restful, Dubbo
+	Path        string            `json:"path" yaml:"path"`
+	Timeout     time.Duration     `json:"timeout" yaml:"timeout"`
+	Description string            `json:"description" yaml:"description"`
+	Filters     []string          `json:"filters" yaml:"filters"`
+	Methods     []Method          `json:"methods" yaml:"methods"`
+	Resources   []Resource        `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 }
 
 // UnmarshalYAML Resource custom UnmarshalYAML

--- a/pkg/filter/header/header.go
+++ b/pkg/filter/header/header.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package header
 
 import (

--- a/pkg/filter/header/header.go
+++ b/pkg/filter/header/header.go
@@ -1,0 +1,52 @@
+package header
+
+import (
+	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/context/http"
+	"strings"
+)
+
+type headerFilter struct {
+}
+
+func New() *headerFilter {
+	return &headerFilter{}
+}
+
+func (h *headerFilter) Do() context.FilterFunc {
+	return func(c context.Context) {
+
+		api := c.GetAPI()
+		headers := api.Headers
+		if len(headers) <= 0 {
+			c.Next()
+			return
+		}
+		switch c.(type) {
+		case *http.HttpContext:
+			hc := c.(*http.HttpContext)
+			urlHeaders := hc.AllHeaders()
+			if len(urlHeaders) <= 0 {
+				c.Abort()
+				return
+			}
+
+			for headerName, headerValue := range headers {
+				urlHeaderValues := urlHeaders.Values(strings.ToLower(headerName))
+				if urlHeaderValues == nil {
+					c.Abort()
+					return
+				}
+				for _, urlHeaderValue := range urlHeaderValues {
+					if urlHeaderValue == headerValue {
+						goto FOUND
+					}
+				}
+				c.Abort()
+			FOUND:
+				continue
+			}
+			break
+		}
+	}
+}

--- a/pkg/filter/header/header.go
+++ b/pkg/filter/header/header.go
@@ -18,14 +18,18 @@
 package header
 
 import (
+	"strings"
+)
+
+import (
 	"github.com/dubbogo/dubbo-go-proxy/pkg/context"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/context/http"
-	"strings"
 )
 
 type headerFilter struct {
 }
 
+// nolint.
 func New() *headerFilter {
 	return &headerFilter{}
 }

--- a/pkg/proxy/listener.go
+++ b/pkg/proxy/listener.go
@@ -19,6 +19,7 @@ package proxy
 
 import (
 	"context"
+	"github.com/dubbogo/dubbo-go-proxy/pkg/filter/header"
 	"log"
 	"net/http"
 	"strconv"
@@ -156,6 +157,8 @@ func addFilter(ctx *h.HttpContext, api router.API) {
 	case config.HTTPRequest:
 		httpFilter(ctx, api.Method.IntegrationRequest)
 	}
+
+	ctx.AppendFilterFunc(header.New().Do())
 
 	ctx.AppendFilterFunc(extension.GetMustFilterFunc(constant.RemoteCallFilter))
 

--- a/pkg/proxy/listener.go
+++ b/pkg/proxy/listener.go
@@ -18,8 +18,11 @@
 package proxy
 
 import (
-	"context"
 	"github.com/dubbogo/dubbo-go-proxy/pkg/filter/header"
+)
+
+import (
+	"context"
 	"log"
 	"net/http"
 	"strconv"
@@ -158,9 +161,7 @@ func addFilter(ctx *h.HttpContext, api router.API) {
 		httpFilter(ctx, api.Method.IntegrationRequest)
 	}
 
-	ctx.AppendFilterFunc(header.New().Do())
-
-	ctx.AppendFilterFunc(extension.GetMustFilterFunc(constant.RemoteCallFilter))
+	ctx.AppendFilterFunc(header.New().Do(), extension.GetMustFilterFunc(constant.RemoteCallFilter))
 
 	ctx.BuildFilters()
 

--- a/pkg/router/api.go
+++ b/pkg/router/api.go
@@ -30,7 +30,7 @@ import (
 type API struct {
 	URLPattern    string `json:"urlPattern" yaml:"urlPattern"`
 	config.Method `json:"method,inline" yaml:"method,inline"`
-	Headers       map[string]string `json:"headers" yaml:"headers"`
+	Headers       map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 }
 
 // GetURIParams returns the values retrieved from the rawURL

--- a/pkg/router/api.go
+++ b/pkg/router/api.go
@@ -30,6 +30,7 @@ import (
 type API struct {
 	URLPattern    string `json:"urlPattern" yaml:"urlPattern"`
 	config.Method `json:"method,inline" yaml:"method,inline"`
+	Headers       map[string]string `json:"headers" yaml:"headers"`
 }
 
 // GetURIParams returns the values retrieved from the rawURL

--- a/pkg/service/api/discovery_service_test.go
+++ b/pkg/service/api/discovery_service_test.go
@@ -120,7 +120,7 @@ func TestLoadAPIFromResource(t *testing.T) {
 			},
 		},
 	}
-	err := loadAPIFromResource("", tempResources, apiDiscSrv)
+	err := loadAPIFromResource("", tempResources, nil, apiDiscSrv)
 	assert.Nil(t, err)
 	rsp, _ := apiDiscSrv.GetAPI("/", config.MethodPut)
 	assert.Equal(t, rsp.URLPattern, "/")
@@ -160,7 +160,7 @@ func TestLoadAPIFromResource(t *testing.T) {
 		},
 	}
 	apiDiscSrv = NewLocalMemoryAPIDiscoveryService()
-	err = loadAPIFromResource("", tempResources, apiDiscSrv)
+	err = loadAPIFromResource("", tempResources, nil, apiDiscSrv)
 	assert.EqualError(t, err, "Path :id in /mock doesn't start with /; Path :ik in /mock doesn't start with /")
 }
 
@@ -171,7 +171,7 @@ func TestLoadAPIFromMethods(t *testing.T) {
 		mock.GetMockAPI(config.MethodPut, "").Method,
 	}
 	apiDiscSrv := NewLocalMemoryAPIDiscoveryService()
-	err := loadAPIFromMethods("/mock", tempMethods, apiDiscSrv)
+	err := loadAPIFromMethods("/mock", tempMethods, nil, apiDiscSrv)
 	rsp, _ := apiDiscSrv.GetAPI("/mock", config.MethodPut)
 	assert.Equal(t, rsp.URLPattern, "/mock")
 	rsp, _ = apiDiscSrv.GetAPI("/mock", config.MethodGet)


### PR DESCRIPTION
**What this PR does**:

add header filter so that haeders of http request from client can match headers in resource。


**Does this PR introduce a user-facing change?**:
```
name: api name
description: api description
resources:
  - path: '/'
    type: restful
    description: resource documentation
    headers:
      header1: value1 # what this pr does
    filters:
      - filter0
    methods:
      - httpVerb: GET
        onAir: true
        inboundRequest:
          requestType: http
          queryStrings:
            - name: id
              required: false
        integrationRequest:
          requestType: dubbo
          mappingParams:
            - name: queryStrings.id
              mapTo: 1
          applicationName: "BDTService"
          interface: "com.ikurento.user.UserProvider"
          method: "GetUser"
          clusterName: "test_dubbo"
```
```release-note

```